### PR TITLE
WARCreate contribution from WAIL-WARCreate core contributor or making contributions upstream to the parent repo

### DIFF
--- a/html/background.html
+++ b/html/background.html
@@ -2,7 +2,7 @@
 <html>
   <head>
   	<script src="../js/punycode.min.js"></script> <!-- Attempt at handling UTF characters gracefully with Blink engine -->
-	<script src="../js/es6-shim.js"></script> <!-- To convert the really high character numbers that are exhibited in image data. Keep this until Chrome supports https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint in EC6 --> 
+	<!--<script src="../js/es6-shim.js"></script> &lt;!&ndash; To convert the really high character numbers that are exhibited in image data. Keep this until Chrome supports https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint in EC6 &ndash;&gt; -->
 	<script type="text/javascript" src="../js/jquery-1.7.min.js"></script>
 	<script src="../js/base64.js"></script>
 	<script src="../js/FileSaver.js"></script>

--- a/js/code.js
+++ b/js/code.js
@@ -8,147 +8,91 @@
  */
 
 // var server = "http://localhost:8080"
-// var server = 'http://warcreate.com'
+var server = 'http://warcreate.com' // eslint-disable-line
 
 // Called when the url of a tab changes.
 function checkForValidUrl (tabId, changeInfo, tab) {
   chrome.pageAction.show(tabId)
 }
 
-// function alertContent () {
-//   chrome.tabs.executeScript(null, {file: 'js/jquery-2.1.1.min.js'}, function () {
-//     chrome.tabs.executeScript(null, {file: 'js/jquery.rc4.js'}, function () {
-//       chrome.tabs.executeScript(null, { file: 'js/alertContent.js' }, function () {})
-//     })
-//   })
-// }
-
-/**
- * Converts images on the webpage into a binary string
- */
-// function encodeImages () {
-//   var images = document.getElementsByTagName('img')
-//   var img = new Image()
-//   img.src = request.url
-//   var canvas = document.createElement('canvas')
-//   canvas.width = img.width
-//   canvas.height = img.height
-//   var context = canvas.getContext('2d')
-//
-//   // console.log((i+": "+images[i].src+"  file type: "+fileType)
-//   var fileType = images[i].src.substr(images[i].src.length - 4).toLowerCase()
-//   if (fileType == '.jpg' || fileType == 'jpeg') { fileType = 'image/jpeg' } else if (fileType == '.png') { fileType = 'image/png' } else if (fileType == '.gif') { fileType = 'image/gif' } else {
-//     var uTransformed = images[i].src.substring(0, images[i].src.indexOf('.jpg')) + '.jpg'
-//     alert('error at image ' + i + ' ' + uTransformed); return
-//   }
-//     // console.log((i+": "+images[i].src+"  file type: "+fileType)
-//
-//   try {
-//     var base64 = canvas.toDataURL(fileType)
-//     img.src = base64
-//   // console.log(("Replaced image "+request.url+" with its base64 encoded form per canvas")
-//   } catch (e) {
-//     alert('Encoding of inline binary content failed!')
-//     console.log(e)
-//     return
-//   }
-//   $(images[i]).replaceWith(img)
-// }
-
-/**
- * UNUSED: Desired functionality is to provide facilities to encrypt data in resulting WARC
- */
-// function encrypt () {
-//   var key = document.getElementById('key').value
-//   if (key === '') { alert('First enter a key for encryption.'); return }
-//   chrome.tabs.executeScript(null, {file: 'js/jquery-2.1.1.min.js'}, function () {
-//     chrome.tabs.executeScript(null, {file: 'js/jquery.rc4.js'}, function () {
-//       chrome.tabs.executeScript(null, {code: "var params = {k:'" + key + "'};"}, function () {
-//         chrome.tabs.executeScript(null, { file: 'js/encryptPage.js' }, function () {})
-//       })
-//     })
-//   })
-// }
-
 /**
  * TODO: Provide 'sequential archiving' wherein a site's hierarchy is referenced
  * and all pages referenced in the hierarchy are captured
+ *
  */
 function sequentialGenerateWarc () {
   var urls = []
-  $(localStorage[ 'spec' ]).find('url').each(function (index) {
+  $(localStorage['spec']).find('url').each(function (index) {
     urls.push($(this).text())
   })
   var uu = 0
 
   function generateWarcFromNextURL (nextUrl) {
-    chrome.tabs.create({ url: nextUrl, active: true },
+    chrome.tabs.create({url: nextUrl, active: true},
       function (tab) {
         chrome.tabs.onUpdated.addListener(function (tabId, info) {
           if (info.status === 'complete') {
-            generateWarc()
+            doGenerateWarc()
             // chrome.tabs.remove(tab.tabId)
             alert('done with ' + (uu + 1) + '/' + urls.length)
-            if (++uu >= urls.length) {
-              return
-            }
-            generateWarcFromNextURL(urls[ uu ])
+            if (++uu >= urls.length) { return }
+            generateWarcFromNextURL(urls[uu])
           }
         })
       }
     )
   }
 
-  generateWarcFromNextURL(urls[ uu ])
+  generateWarcFromNextURL(urls[uu])
 }
 
 /**
  * Calls and aggregates the results of the functions that progressively create a
  * string representative of the contents of the WARC file being generated.
  */
-function generateWarc () {
+function doGenerateWarc () {
   // console.log(("generate_warc start")
 
-  // var imageData = []
-  // var imageURIs = []
+  var imageData = []
+  var imageURIs = []
   // console.log(("generate_warc")
-  chrome.tabs.executeScript(null, { file: 'js/jquery-2.1.1.min.js' }, function () { /* Dependency for hash library and general goodness */
-    chrome.tabs.executeScript(null, { file: 'js/jquery.rc4.js' }, function () { /* Hash library */
-      chrome.tabs.executeScript(null, { file: 'js/date.js' }, function () { /* Good date formatting library */
-        // var uris = []
-        // var datum = []
+  chrome.tabs.executeScript(null, {file: 'js/jquery-2.1.1.min.js'}, function () { /* Dependency for hash library and general goodness */
+    chrome.tabs.executeScript(null, {file: 'js/jquery.rc4.js'}, function () { /* Hash library */
+      chrome.tabs.executeScript(null, {file: 'js/date.js'}, function () { /* Good date formatting library */
+        var uris = []
+        var datum = []
         chrome.tabs.getSelected(null, function (tab) {
           // chrome.pageAction.setIcon({path:"../icons/icon-running.png",tabId:tab.id})
-          var port = chrome.tabs.connect(tab.id, { name: 'warcreate' }) // create a persistent connection
-          port.postMessage({ url: tab.url, method: 'getHTML' }) // fetch the html of the page, in content.js
+          var port = chrome.tabs.connect(tab.id, {name: 'warcreate'}) // create a persistent connection
+          port.postMessage({url: tab.url, method: 'getHTML'}) // fetch the html of the page, in content.js
 
-          // var imageDataFilledTo = -1
+          var imageDataFilledTo = -1
 
           // perform the first listener, populate the binary image data
           // console.log(("adding listener")
           port.onMessage.addListener(function (msg) { // get image base64 data
             // console.log(("About to generateWARC(). Next should be callback.")
 
-            var fileName = (new Date().toISOString()).replace(/:|\-|\T|\Z|\./g, '') + '.warc'
+            var fileName = (new Date().toISOString()).replace(/:|-|T|Z|\./g, '') + '.warc'
 
             // If the user has specified a custom filename format, apply it here
-            if (localStorage[ 'filenameScheme' ] && localStorage[ 'filenameScheme' ].length > 0) {
-              fileName = moment().format(localStorage[ 'filenameScheme' ]) + '.warc'
+            if (localStorage['filenameScheme'] && localStorage['filenameScheme'].length > 0) {
+              fileName = moment().format(localStorage['filenameScheme']) + '.warc'
             }
-
-            chrome.extension.sendRequest({
-                url: tab.url,
-                method: 'generateWarc',
-                docHtml: msg.html,
-                file: fileName,
-                imgURIs: msg.uris,
-                imgData: msg.data,
-                cssURIs: msg.cssuris,
-                cssData: msg.cssdata,
-                jsURIs: msg.jsuris,
-                jsData: msg.jsdata,
-                outlinks: msg.outlinks
-              },
+            var requestToBeSent = {
+              url: tab.url,
+              method: 'generateWarc',
+              docHtml: msg.html,
+              file: fileName,
+              imgURIs: msg.uris,
+              imgData: msg.data,
+              cssURIs: msg.cssuris,
+              cssData: msg.cssdata,
+              jsURIs: msg.jsuris,
+              jsData: msg.jsdata,
+              outlinks: msg.outlinks
+            }
+            chrome.extension.sendRequest(requestToBeSent,
               function (response) { // the callback to sendRequest
 
                 /*
@@ -213,21 +157,21 @@ function generateWarc () {
  * Sets up the popup activated when the extensions's icon is clicked.
  */
 window.onload = function () {
-  // var background = chrome.extension.getBackgroundPage()
+  var background = chrome.extension.getBackgroundPage()
 
   var buttonContainer = document.getElementById('buttonContainer')
 
-  // var sButton = document.getElementById('submit')
-  // var acButton = document.getElementById('alertContent')
+  var sButton = document.getElementById('submit')
+  var acButton = document.getElementById('alertContent')
   // var encryptButton = document.getElementById('encrypt')
-  // var encodeButton = document.getElementById('encodeImages')
+  var encodeButton = document.getElementById('encodeImages')
 
   // if a website is recognized from the spec, show the "Cohesive archive"
   var caButtonDOM = document.createElement('input')
   caButtonDOM.type = 'button'
   caButtonDOM.id = 'generateCohesiveWARC'
   caButtonDOM.disabled = 'disabled'
-  // var t
+  var t
 
   caButtonDOM.value = 'Generate WARC for site'
 
@@ -248,8 +192,8 @@ window.onload = function () {
   errorText.id = 'errorText'
   errorText.target = '_blank'
   var status = document.createElement('input')
-  status.id = 'status';
-  status.type = 'text';
+  status.id = 'status'
+  status.type = 'text'
   status.value = ''
 
   if (!buttonContainer) { return }
@@ -264,7 +208,7 @@ window.onload = function () {
   $('#status').css('display', 'none') // initially hide the status block
 
   var gwButton = document.getElementById('generateWarc')
-  gwButton.onclick = generateWarc
+  gwButton.onclick = doGenerateWarc
 
   var clsButton = document.getElementById('clearLocalStorage')
 
@@ -281,7 +225,12 @@ window.onload = function () {
 // Listen for any changes to the URL of any tab.
 chrome.tabs.onUpdated.addListener(checkForValidUrl)
 
-// var headers = ''
+var headers = ''
+
+/**
+ * address #79 by keeping track per URL what headers we have already concatenated
+ */
+var requestHeadersTracking = []
 
 var responseHeaders = []
 var requestHeaders = []
@@ -290,15 +239,15 @@ var CRLF = '\r\n'
 var currentTabId = -1
 
 chrome.tabs.getSelected(null, function (tab) {
-  chrome.storage.local.set({ 'lastTabId': tab.id })
+  chrome.storage.local.set({'lastTabId': tab.id})
 
   chrome.storage.local.get('lastTabId', function (result) {
     // $("body").append("Tab IDY: "+result.lastTabId)
     // $("body").append(tab.url)
   })
 
-  var port = chrome.tabs.connect(tab.id, { name: 'getImageData' }) // create a persistent connection
-  port.postMessage({ url: tab.url, method: 'getImageData' })
+  var port = chrome.tabs.connect(tab.id, {name: 'getImageData'}) // create a persistent connection
+  port.postMessage({url: tab.url, method: 'getImageData'})
   port.onMessage.addListener(function (msg) {
     /* if(msg.method == "getImageDataRet"){ //OBSOLETE HERE BELOW,
      var imageURIsForWhichWeHaveData = Object.keys(JSON.parse(msg.imageData))
@@ -327,56 +276,73 @@ chrome.tabs.getSelected(null, function (tab) {
  */
 chrome.webRequest.onHeadersReceived.addListener(
   function (resp) {
-    responseHeaders[ resp.url ] = ''
-    responseHeaders[ resp.url ] += resp.statusLine + CRLF
+    responseHeaders[resp.url] = `${resp.statusLine}${CRLF}`
 
     // console.log(("- Response Headers received for "+resp.url+" in tab "+resp.tabId)
     for (var key in resp.responseHeaders) {
-      responseHeaders[ resp.url ] += resp.responseHeaders[ key ].name + ': ' + resp.responseHeaders[ key ].value + CRLF
+      responseHeaders[resp.url] += `${resp.responseHeaders[key].name}: ${resp.responseHeaders[key].value}${CRLF}`
     }
     // console.log(responseHeaders[resp.url])
   }
-  , { urls: [ 'http://*/*', 'https://*/*' ], tabId: currentTabId }, [ 'responseHeaders', 'blocking' ])
+  , {urls: ['http://*/*', 'https://*/*'], tabId: currentTabId}, ['responseHeaders', 'blocking'])
 
 /**
  * Stores HTTP request headers into an object array with URI as key.
+ * issue #79, these headers are not available here:
+ * Authorization,Cache-Control,Connection,Content-Length,Host,If-Modified-Since,If-None-Match,If-Range
+ * Partial-Data,Pragma,Proxy-Authorization,Proxy-Connection,Transfer-Encoding
+ * see https://developer.chrome.com/extensions/webRequest
  */
-chrome.webRequest.onBeforeSendHeaders.addListener(
-  function (req) {
-    requestHeaders[ req.url ] = ''
+chrome.webRequest.onBeforeSendHeaders.addListener(function (req) {
+  var path = req.url.substring(req.url.match(/[a-zA-Z0-9]\//).index + 1)
 
-    var path = req.url.substring(req.url.match(/[a-zA-Z0-9]\//).index + 1)
+  // per #79 keep track of already concatenated headers for warc string
+  if (requestHeadersTracking[req.url] === null || requestHeadersTracking[req.url] === undefined) {
+    requestHeadersTracking[req.url] = new Set()
+  } else {
+    requestHeadersTracking[req.url].clear()
+  }
+  requestHeaders[req.url] = `${req.method} ${path} HTTP/1.1${CRLF}`
+  // requestHeaders[req.url] += req.method + ' ' + path + ' ' + FABRICATED_httpVersion + CRLF
+  // console.log(("- Request headers received for "+req.url)
+  for (var key in req.requestHeaders) {
+    requestHeaders[req.url] += `${req.requestHeaders[key].name}: ${req.requestHeaders[key].value}${CRLF}`
+    requestHeadersTracking[req.url].add(req.requestHeaders[key].name)
+  }
+}, {urls: ['http://*/*', 'https://*/*'], tabId: currentTabId}, ['requestHeaders', 'blocking'])
 
-    var FABRICATED_httpVersion = 'HTTP/1.1'
-    requestHeaders[ req.url ] += req.method + ' ' + path + ' ' + FABRICATED_httpVersion + CRLF
-    // console.log(("- Request headers received for "+req.url)
-    for (var key in req.requestHeaders) {
-      requestHeaders[ req.url ] += req.requestHeaders[ key ].name + ': ' + req.requestHeaders[ key ].value + CRLF
+/**
+ * Stores HTTP request headers into an object array with URI as key.
+ * fix for issue #79, see explanation in onBeforeSendHeaders and documentation for requestHeadersTracking
+ */
+chrome.webRequest.onSendHeaders.addListener(function (req) {
+  for (var key in req.requestHeaders) {
+    if (!requestHeadersTracking[req.url].has(req.requestHeaders[key].name)) {
+      requestHeaders[req.url] += `${req.requestHeaders[key].name}: ${req.requestHeaders[key].value}${CRLF}`
+      requestHeadersTracking[req.url].add(req.requestHeaders[key].name)
     }
   }
-  , { urls: [ 'http://*/*', 'https://*/*' ], tabId: currentTabId }, [ 'requestHeaders', 'blocking' ])
+}, {urls: ['http://*/*', 'https://*/*'], tabId: currentTabId}, ['requestHeaders'])
 
 /**
  * Captures information about redirects that otherwise would be transparent to
  * the browser.
  */
 chrome.webRequest.onBeforeRedirect.addListener(function (resp) {
-  responseHeaders[ resp.url ] = ''
-  responseHeaders[ resp.url ] += resp.statusLine + CRLF
+  responseHeaders[resp.url] += `${resp.statusLine}${CRLF}`
 
   // console.log(("--------------Redirect Response Headers for "+resp.url+" --------------")
   for (var key in resp.responseHeaders) {
-    responseHeaders[ resp.url ] += resp.responseHeaders[ key ].name + ': ' + resp.responseHeaders[ key ].value + CRLF
+    responseHeaders[resp.url] += `${resp.responseHeaders[key].name}: ${resp.responseHeaders[key].value}${CRLF}`
   }
 // console.log((responseHeaders[resp.url])
-}, { urls: [ 'http://*/*', 'https://*/*' ], tabId: currentTabId }, [ 'responseHeaders' ])
+}, {urls: ['http://*/*', 'https://*/*'], tabId: currentTabId}, ['responseHeaders'])
 
 /* ************************************************************
 
  UTILITY FUNCTIONS
 
  ************************************************************ */
-
 /**
  * From https://developer.mozilla.org/en-US/docs/Web/API/window.btoa
  * Converts UTF-8 to base 64 data
@@ -392,10 +358,76 @@ function utf8_to_b64 (str) {
 function b64_to_utf8 (str) {
   return decodeURIComponent(escape(window.atob(str)))
 }
-
 /**
  * UNUSED: A means of capturing any particular values that are only present in
  * this handler.
  */
 chrome.webRequest.onResponseStarted.addListener(
-  function (details) {}, { urls: [ 'http://*/*', 'https://*/*' ] }, [ 'responseHeaders' ])
+  function (details) {}, {urls: ['http://*/*', 'https://*/*']}, ['responseHeaders'])
+
+/* BEGIN UNUSED CODE */
+// function alertContent () {
+//   chrome.tabs.executeScript(null, {file: 'js/jquery-2.1.1.min.js'}, function () {
+//     chrome.tabs.executeScript(null, {file: 'js/jquery.rc4.js'}, function () {
+//       chrome.tabs.executeScript(null, {file: 'js/alertContent.js'}, function () {})
+//     })
+//   })
+// }
+
+// /**
+//  * Converts images on the webpage into a binary string
+//  */
+// function encodeImages () {
+//   var images = document.getElementsByTagName('img')
+//   var img = new Image()
+//   img.src = request.url
+//   var canvas = document.createElement('canvas')
+//   canvas.width = img.width
+//   canvas.height = img.height
+//   var context = canvas.getContext('2d')
+//
+//   // console.log((i+": "+images[i].src+"  file type: "+fileType)
+//   var fileType = images[i].src.substr(images[i].src.length - 4).toLowerCase()
+//   if (fileType === '.jpg' || fileType === 'jpeg') {
+//     fileType = 'image/jpeg'
+//   } else if (fileType === '.png') {
+//     fileType = 'image/png'
+//   } else if (fileType === '.gif') {
+//     fileType = 'image/gif'
+//   } else {
+//     var uTransformed = images[i].src.substring(0, images[i].src.indexOf('.jpg')) + '.jpg'
+//     alert('error at image ' + i + ' ' + uTransformed)
+//     return
+//   }
+//   // console.log((i+": "+images[i].src+"  file type: "+fileType)
+//
+//   try {
+//     var base64 = canvas.toDataURL(fileType)
+//     img.src = base64
+//     // console.log(("Replaced image "+request.url+" with its base64 encoded form per canvas")
+//   } catch (e) {
+//     alert('Encoding of inline binary content failed!')
+//     console.log(e)
+//     return
+//   }
+//   $(images[i]).replaceWith(img)
+// }
+
+// /**
+//  * UNUSED: Desired functionality is to provide facilities to encrypt data in resulting WARC
+//  */
+// function encrypt () {
+//   var key = document.getElementById('key').value
+//   if (key === '') {
+//     alert('First enter a key for encryption.')
+//     return
+//   }
+//   chrome.tabs.executeScript(null, {file: 'js/jquery-2.1.1.min.js'}, function () {
+//     chrome.tabs.executeScript(null, {file: 'js/jquery.rc4.js'}, function () {
+//       chrome.tabs.executeScript(null, {code: 'var params = {k:\'' + key + '\'};'}, function () {
+//         chrome.tabs.executeScript(null, {file: 'js/encryptPage.js'}, function () {})
+//       })
+//     })
+//   })
+// }
+/* END UNUSED CODE */

--- a/js/code.js
+++ b/js/code.js
@@ -5,201 +5,202 @@
  *
  * See included LICENSE file for reuse information
  *
-*/
+ */
 
 // var server = "http://localhost:8080"
-var server = 'http://warcreate.com'
+// var server = 'http://warcreate.com'
 
 // Called when the url of a tab changes.
 function checkForValidUrl (tabId, changeInfo, tab) {
   chrome.pageAction.show(tabId)
 }
 
-function alertContent () {
-  chrome.tabs.executeScript(null, {file: 'js/jquery-2.1.1.min.js'}, function () {
-    chrome.tabs.executeScript(null, {file: 'js/jquery.rc4.js'}, function () {
-      chrome.tabs.executeScript(null, { file: 'js/alertContent.js' }, function () {})
-    })
-  })
-}
+// function alertContent () {
+//   chrome.tabs.executeScript(null, {file: 'js/jquery-2.1.1.min.js'}, function () {
+//     chrome.tabs.executeScript(null, {file: 'js/jquery.rc4.js'}, function () {
+//       chrome.tabs.executeScript(null, { file: 'js/alertContent.js' }, function () {})
+//     })
+//   })
+// }
 
 /**
  * Converts images on the webpage into a binary string
-*/
-function encodeImages () {
-  var images = document.getElementsByTagName('img')
-  var img = new Image()
-  img.src = request.url
-  var canvas = document.createElement('canvas')
-  canvas.width = img.width
-  canvas.height = img.height
-  var context = canvas.getContext('2d')
-
-  // console.log((i+": "+images[i].src+"  file type: "+fileType)
-  var fileType = images[i].src.substr(images[i].src.length - 4).toLowerCase()
-  if (fileType == '.jpg' || fileType == 'jpeg') {fileType = 'image/jpeg';}
-  else if (fileType == '.png') {fileType = 'image/png';}
-  else if (fileType == '.gif') {fileType = 'image/gif';}else {
-    var uTransformed = images[i].src.substring(0, images[i].src.indexOf('.jpg')) + '.jpg'
-    alert('error at image ' + i + ' ' + uTransformed); return; }
-    // console.log((i+": "+images[i].src+"  file type: "+fileType)
-
-  try {
-    var base64 = canvas.toDataURL(fileType)
-    img.src = base64
-  // console.log(("Replaced image "+request.url+" with its base64 encoded form per canvas")
-  } catch(e) {
-    alert('Encoding of inline binary content failed!')
-    console.log(e)
-    return
-  }
-  $(images[i]).replaceWith(img)
-}
+ */
+// function encodeImages () {
+//   var images = document.getElementsByTagName('img')
+//   var img = new Image()
+//   img.src = request.url
+//   var canvas = document.createElement('canvas')
+//   canvas.width = img.width
+//   canvas.height = img.height
+//   var context = canvas.getContext('2d')
+//
+//   // console.log((i+": "+images[i].src+"  file type: "+fileType)
+//   var fileType = images[i].src.substr(images[i].src.length - 4).toLowerCase()
+//   if (fileType == '.jpg' || fileType == 'jpeg') { fileType = 'image/jpeg' } else if (fileType == '.png') { fileType = 'image/png' } else if (fileType == '.gif') { fileType = 'image/gif' } else {
+//     var uTransformed = images[i].src.substring(0, images[i].src.indexOf('.jpg')) + '.jpg'
+//     alert('error at image ' + i + ' ' + uTransformed); return
+//   }
+//     // console.log((i+": "+images[i].src+"  file type: "+fileType)
+//
+//   try {
+//     var base64 = canvas.toDataURL(fileType)
+//     img.src = base64
+//   // console.log(("Replaced image "+request.url+" with its base64 encoded form per canvas")
+//   } catch (e) {
+//     alert('Encoding of inline binary content failed!')
+//     console.log(e)
+//     return
+//   }
+//   $(images[i]).replaceWith(img)
+// }
 
 /**
  * UNUSED: Desired functionality is to provide facilities to encrypt data in resulting WARC
-*/
-function encrypt () {
-  var key = document.getElementById('key').value
-  if (key === '') {alert('First enter a key for encryption.'); return;}
-  chrome.tabs.executeScript(null, {file: 'js/jquery-2.1.1.min.js'}, function () {
-    chrome.tabs.executeScript(null, {file: 'js/jquery.rc4.js'}, function () {
-      chrome.tabs.executeScript(null, {code: "var params = {k:'" + key + "'};"}, function () {
-        chrome.tabs.executeScript(null, { file: 'js/encryptPage.js' }, function () {})
-      })
-    })
-  })
-}
+ */
+// function encrypt () {
+//   var key = document.getElementById('key').value
+//   if (key === '') { alert('First enter a key for encryption.'); return }
+//   chrome.tabs.executeScript(null, {file: 'js/jquery-2.1.1.min.js'}, function () {
+//     chrome.tabs.executeScript(null, {file: 'js/jquery.rc4.js'}, function () {
+//       chrome.tabs.executeScript(null, {code: "var params = {k:'" + key + "'};"}, function () {
+//         chrome.tabs.executeScript(null, { file: 'js/encryptPage.js' }, function () {})
+//       })
+//     })
+//   })
+// }
 
 /**
  * TODO: Provide 'sequential archiving' wherein a site's hierarchy is referenced
  * and all pages referenced in the hierarchy are captured
-*/
-function sequential_generate_Warc () {
+ */
+function sequentialGenerateWarc () {
   var urls = []
-  $(localStorage['spec']).find('url').each(function (index) {
+  $(localStorage[ 'spec' ]).find('url').each(function (index) {
     urls.push($(this).text())
   })
   var uu = 0
+
   function generateWarcFromNextURL (nextUrl) {
-    chrome.tabs.create({url: nextUrl, active: true},
+    chrome.tabs.create({ url: nextUrl, active: true },
       function (tab) {
         chrome.tabs.onUpdated.addListener(function (tabId, info) {
-          if (info.status == 'complete') {
-            generate_Warc()
+          if (info.status === 'complete') {
+            generateWarc()
             // chrome.tabs.remove(tab.tabId)
             alert('done with ' + (uu + 1) + '/' + urls.length)
-            if (++uu >= urls.length) {return;}
-            generateWarcFromNextURL(urls[uu])
+            if (++uu >= urls.length) {
+              return
+            }
+            generateWarcFromNextURL(urls[ uu ])
           }
         })
       }
     )
   }
 
-  generateWarcFromNextURL(urls[uu])
+  generateWarcFromNextURL(urls[ uu ])
 }
 
 /**
- * Calls and aggregates the results of the functions that progressively create a 
+ * Calls and aggregates the results of the functions that progressively create a
  * string representative of the contents of the WARC file being generated.
-*/
-function generate_Warc () {
+ */
+function generateWarc () {
   // console.log(("generate_warc start")
 
-  var imageData = []
-  var imageURIs = []
+  // var imageData = []
+  // var imageURIs = []
   // console.log(("generate_warc")
-  chrome.tabs.executeScript(null, {file: 'js/jquery-2.1.1.min.js'}, function () { /* Dependency for hash library and general goodness*/
-    chrome.tabs.executeScript(null, {file: 'js/jquery.rc4.js'}, function () { /* Hash library */
-      chrome.tabs.executeScript(null, {file: 'js/date.js'}, function () { /* Good date formatting library */
-        var uris = []
-        var datum = []
+  chrome.tabs.executeScript(null, { file: 'js/jquery-2.1.1.min.js' }, function () { /* Dependency for hash library and general goodness */
+    chrome.tabs.executeScript(null, { file: 'js/jquery.rc4.js' }, function () { /* Hash library */
+      chrome.tabs.executeScript(null, { file: 'js/date.js' }, function () { /* Good date formatting library */
+        // var uris = []
+        // var datum = []
         chrome.tabs.getSelected(null, function (tab) {
           // chrome.pageAction.setIcon({path:"../icons/icon-running.png",tabId:tab.id})
-          var port = chrome.tabs.connect(tab.id, {name: 'warcreate'}) // create a persistent connection
-          port.postMessage({url: tab.url, method: 'getHTML'}); // fetch the html of the page, in content.js
+          var port = chrome.tabs.connect(tab.id, { name: 'warcreate' }) // create a persistent connection
+          port.postMessage({ url: tab.url, method: 'getHTML' }) // fetch the html of the page, in content.js
 
-          var imageDataFilledTo = -1
+          // var imageDataFilledTo = -1
 
           // perform the first listener, populate the binary image data
           // console.log(("adding listener")
-          port.onMessage.addListener(function (msg) { // get image base64 data		
+          port.onMessage.addListener(function (msg) { // get image base64 data
             // console.log(("About to generateWARC(). Next should be callback.")
 
             var fileName = (new Date().toISOString()).replace(/:|\-|\T|\Z|\./g, '') + '.warc'
 
             // If the user has specified a custom filename format, apply it here
-            if (localStorage['filenameScheme'] && localStorage['filenameScheme'].length > 0) {
-              fileName = moment().format(localStorage['filenameScheme']) + '.warc'
+            if (localStorage[ 'filenameScheme' ] && localStorage[ 'filenameScheme' ].length > 0) {
+              fileName = moment().format(localStorage[ 'filenameScheme' ]) + '.warc'
             }
 
             chrome.extension.sendRequest({
-              url: tab.url,
-              method: 'generateWarc',
-              docHtml: msg.html,
-              file: fileName,
-              imgURIs: msg.uris,
-              imgData: msg.data,
-              cssURIs: msg.cssuris,
-              cssData: msg.cssdata,
-              jsURIs: msg.jsuris,
-              jsData: msg.jsdata,
-            outlinks: msg.outlinks},
+                url: tab.url,
+                method: 'generateWarc',
+                docHtml: msg.html,
+                file: fileName,
+                imgURIs: msg.uris,
+                imgData: msg.data,
+                cssURIs: msg.cssuris,
+                cssData: msg.cssdata,
+                jsURIs: msg.jsuris,
+                jsData: msg.jsdata,
+                outlinks: msg.outlinks
+              },
               function (response) { // the callback to sendRequest
-                return
-              /*
-              //OBSOLETE SAVE CODE BELOW, GOOD FOR FETCHING RESOURCE POST-LOAD
-              
-							console.log("generateWARC callback executed, about to write to file")
-							
-							//var bb = new BlobBuilder
-							//bb.append(response.d)
-							//localStorage['data'] = response.d
-							
-							function uploadSuccess(d,t,j){
-								console.log("* Upload succeeded! Three call variables follow this message.")
-								console.log(d)
-								console.log(t)
-								console.log(j)
-							}
-							
-							function uploadFail(x,t,e){
-								console.log("There was an error uploading the file.")
-							}
-							
-							console.log("Here's the data that's to be written")
-							console.log(response.x)
-							
-						
-							if(!localStorage['uploadTo'] || localStorage['uploadTo'].length == 0){
-								//saveAs(bb.getBlob("text/plain;charset=utf-8"), fileName)
-								console.log("Responding!")
-								console.log(response.x)
-								console.log(JSON.parse(response.x).data)
-								//saveAs(JSON.parse(response.x).data, fileName)
-				
-							} else {
-								console.log("Uploading!"+localStorage['uploadTo'])
-								
-								$.ajax({
-									type: "POST",
-									url: localStorage['uploadTo'],
-									data: {data: response.d}//localStorage['data']} //testing file upload
-									}
-								  )
-								.done(uploadSuccess)
-								.fail(uploadFail)
-							}
-							
-							
-							console.log("Done!")
-							chrome.pageAction.setIcon({path:"../icons/icon-check.png",tabId:tab.id})
-							responseHeaders = new Array()
-							requestHeaders = new Array()
-							imageData = new Array()
-							var imageURIs = new Array()
-							msg = null;*/
+
+                /*
+                 //OBSOLETE SAVE CODE BELOW, GOOD FOR FETCHING RESOURCE POST-LOAD
+
+                 console.log("generateWARC callback executed, about to write to file")
+
+                 //var bb = new BlobBuilder
+                 //bb.append(response.d)
+                 //localStorage['data'] = response.d
+
+                 function uploadSuccess(d,t,j){
+                 console.log("* Upload succeeded! Three call variables follow this message.")
+                 console.log(d)
+                 console.log(t)
+                 console.log(j)
+                 }
+
+                 function uploadFail(x,t,e){
+                 console.log("There was an error uploading the file.")
+                 }
+
+                 console.log("Here's the data that's to be written")
+                 console.log(response.x)
+
+                 if(!localStorage['uploadTo'] || localStorage['uploadTo'].length == 0){
+                 //saveAs(bb.getBlob("text/plain;charset=utf-8"), fileName)
+                 console.log("Responding!")
+                 console.log(response.x)
+                 console.log(JSON.parse(response.x).data)
+                 //saveAs(JSON.parse(response.x).data, fileName)
+
+                 } else {
+                 console.log("Uploading!"+localStorage['uploadTo'])
+
+                 $.ajax({
+                 type: "POST",
+                 url: localStorage['uploadTo'],
+                 data: {data: response.d}//localStorage['data']} //testing file upload
+                 }
+                 )
+                 .done(uploadSuccess)
+                 .fail(uploadFail)
+                 }
+
+                 console.log("Done!")
+                 chrome.pageAction.setIcon({path:"../icons/icon-check.png",tabId:tab.id})
+                 responseHeaders = new Array()
+                 requestHeaders = new Array()
+                 imageData = new Array()
+                 var imageURIs = new Array()
+                 msg = null; */
               })
           })
         })
@@ -210,39 +211,48 @@ function generate_Warc () {
 
 /**
  * Sets up the popup activated when the extensions's icon is clicked.
-*/
+ */
 window.onload = function () {
-  var background = chrome.extension.getBackgroundPage()
+  // var background = chrome.extension.getBackgroundPage()
 
   var buttonContainer = document.getElementById('buttonContainer')
 
-  var sButton = document.getElementById('submit')
-  var acButton = document.getElementById('alertContent')
+  // var sButton = document.getElementById('submit')
+  // var acButton = document.getElementById('alertContent')
   // var encryptButton = document.getElementById('encrypt')
-  var encodeButton = document.getElementById('encodeImages')
+  // var encodeButton = document.getElementById('encodeImages')
 
   // if a website is recognized from the spec, show the "Cohesive archive"
   var caButtonDOM = document.createElement('input')
-  caButtonDOM.type = 'button'; caButtonDOM.id = 'generateCohesiveWARC';  caButtonDOM.disabled = 'disabled'
-  var t
+  caButtonDOM.type = 'button'
+  caButtonDOM.id = 'generateCohesiveWARC'
+  caButtonDOM.disabled = 'disabled'
+  // var t
 
   caButtonDOM.value = 'Generate WARC for site'
 
   // create buttons for popup
   var gwButtonDOM = document.createElement('input')
-  gwButtonDOM.type = 'button'; gwButtonDOM.id = 'generateWarc'; gwButtonDOM.value = 'Generate WARC'
+  gwButtonDOM.type = 'button'
+  gwButtonDOM.id = 'generateWarc'
+  gwButtonDOM.value = 'Generate WARC'
   var clsButtonDOM = document.createElement('input')
-  clsButtonDOM.type = 'button'; clsButtonDOM.id = 'clearLocalStorage'; clsButtonDOM.value = 'Clear LocalStorage'
+  clsButtonDOM.type = 'button'
+  clsButtonDOM.id = 'clearLocalStorage'
+  clsButtonDOM.value = 'Clear LocalStorage'
 
   // For debugging, display content already captured
   // var dcButtonDOM = document.createElement('input'); dcButtonDOM.type = "button"; dcButtonDOM.id = "displayCaptured"; gwButtonDOM.value = "Show pending content"
 
   var errorText = document.createElement('a')
-  errorText.id = 'errorText'; errorText.target = '_blank'
+  errorText.id = 'errorText'
+  errorText.target = '_blank'
   var status = document.createElement('input')
-  status.id = 'status'; status.type = 'text'; status.value = ''
+  status.id = 'status';
+  status.type = 'text';
+  status.value = ''
 
-  if (!buttonContainer) {return;}
+  if (!buttonContainer) { return }
 
   // add buttons to DOM
   buttonContainer.appendChild(gwButtonDOM)
@@ -254,7 +264,7 @@ window.onload = function () {
   $('#status').css('display', 'none') // initially hide the status block
 
   var gwButton = document.getElementById('generateWarc')
-  gwButton.onclick = generate_Warc
+  gwButton.onclick = generateWarc
 
   var clsButton = document.getElementById('clearLocalStorage')
 
@@ -265,13 +275,13 @@ window.onload = function () {
   $(ulButton).css('display', 'none')
   $(caButton).css('display', 'none')
 
-  $(clsButton).css('display', 'none'); // clear local storage, used in debugging
-  caButton.onclick = sequential_generate_Warc
+  $(clsButton).css('display', 'none') // clear local storage, used in debugging
+  caButton.onclick = sequentialGenerateWarc
 }
 // Listen for any changes to the URL of any tab.
 chrome.tabs.onUpdated.addListener(checkForValidUrl)
 
-var headers = ''
+// var headers = ''
 
 var responseHeaders = []
 var requestHeaders = []
@@ -280,105 +290,105 @@ var CRLF = '\r\n'
 var currentTabId = -1
 
 chrome.tabs.getSelected(null, function (tab) {
-  chrome.storage.local.set({'lastTabId': tab.id})
+  chrome.storage.local.set({ 'lastTabId': tab.id })
 
   chrome.storage.local.get('lastTabId', function (result) {
     // $("body").append("Tab IDY: "+result.lastTabId)
     // $("body").append(tab.url)
   })
 
-  var port = chrome.tabs.connect(tab.id, {name: 'getImageData'}) // create a persistent connection
-  port.postMessage({url: tab.url, method: 'getImageData'})
+  var port = chrome.tabs.connect(tab.id, { name: 'getImageData' }) // create a persistent connection
+  port.postMessage({ url: tab.url, method: 'getImageData' })
   port.onMessage.addListener(function (msg) {
-    /*if(msg.method == "getImageDataRet"){ //OBSOLETE HERE BELOW, 
-    	var imageURIsForWhichWeHaveData = Object.keys(JSON.parse(msg.imageData))
-    	for(var uu=0; uu<imageURIsForWhichWeHaveData.length; uu++){
-    		console.log("- Image data in local storage for "+imageURIsForWhichWeHaveData[uu])
-    	}
+    /* if(msg.method == "getImageDataRet"){ //OBSOLETE HERE BELOW,
+     var imageURIsForWhichWeHaveData = Object.keys(JSON.parse(msg.imageData))
+     for(var uu=0; uu<imageURIsForWhichWeHaveData.length; uu++){
+     console.log("- Image data in local storage for "+imageURIsForWhichWeHaveData[uu])
+     }
 
-    	chrome.storage.local.set({'imageData':msg.imageData},
-    		function(){
-    			console.log("Checking if there was an error in setting the data")
-    			if(chrome.runtime.lastError){
-    				alert("Error in set data")
-    			}else {
-    				console.log("There was no data for setting this image in Chrome.Storage.Local")
-    			}
-    		}
-    	
-    	);	
-    	//localStorage["imageData"] = msg.imageData
-    }*/
+     chrome.storage.local.set({'imageData':msg.imageData},
+     function(){
+     console.log("Checking if there was an error in setting the data")
+     if(chrome.runtime.lastError){
+     alert("Error in set data")
+     }else {
+     console.log("There was no data for setting this image in Chrome.Storage.Local")
+     }
+     }
+
+     );
+     //localStorage["imageData"] = msg.imageData
+     } */
   })
 })
 
 /**
  * Stores HTTP response headers into an object array with URI as key.
-*/
+ */
 chrome.webRequest.onHeadersReceived.addListener(
   function (resp) {
-    responseHeaders[resp.url] = ''
-    responseHeaders[resp.url] += resp.statusLine + CRLF
+    responseHeaders[ resp.url ] = ''
+    responseHeaders[ resp.url ] += resp.statusLine + CRLF
 
     // console.log(("- Response Headers received for "+resp.url+" in tab "+resp.tabId)
     for (var key in resp.responseHeaders) {
-      responseHeaders[resp.url] += resp.responseHeaders[key].name + ': ' + resp.responseHeaders[key].value + CRLF
+      responseHeaders[ resp.url ] += resp.responseHeaders[ key ].name + ': ' + resp.responseHeaders[ key ].value + CRLF
     }
-  // console.log(responseHeaders[resp.url])
+    // console.log(responseHeaders[resp.url])
   }
-  , { urls: ['http://*/*', 'https://*/*'], tabId: currentTabId }, ['responseHeaders', 'blocking'])
+  , { urls: [ 'http://*/*', 'https://*/*' ], tabId: currentTabId }, [ 'responseHeaders', 'blocking' ])
 
 /**
  * Stores HTTP request headers into an object array with URI as key.
-*/
+ */
 chrome.webRequest.onBeforeSendHeaders.addListener(
   function (req) {
-    requestHeaders[req.url] = ''
+    requestHeaders[ req.url ] = ''
 
     var path = req.url.substring(req.url.match(/[a-zA-Z0-9]\//).index + 1)
 
     var FABRICATED_httpVersion = 'HTTP/1.1'
-    requestHeaders[req.url] += req.method + ' ' + path + ' ' + FABRICATED_httpVersion + CRLF
+    requestHeaders[ req.url ] += req.method + ' ' + path + ' ' + FABRICATED_httpVersion + CRLF
     // console.log(("- Request headers received for "+req.url)
     for (var key in req.requestHeaders) {
-      requestHeaders[req.url] += req.requestHeaders[key].name + ': ' + req.requestHeaders[key].value + CRLF
+      requestHeaders[ req.url ] += req.requestHeaders[ key ].name + ': ' + req.requestHeaders[ key ].value + CRLF
     }
   }
-  , { urls: ['http://*/*', 'https://*/*'], tabId: currentTabId }, ['requestHeaders', 'blocking'])
+  , { urls: [ 'http://*/*', 'https://*/*' ], tabId: currentTabId }, [ 'requestHeaders', 'blocking' ])
 
 /**
- * Captures information about redirects that otherwise would be transparent to 
+ * Captures information about redirects that otherwise would be transparent to
  * the browser.
-*/
+ */
 chrome.webRequest.onBeforeRedirect.addListener(function (resp) {
-  responseHeaders[resp.url] = ''
-  responseHeaders[resp.url] += resp.statusLine + CRLF
+  responseHeaders[ resp.url ] = ''
+  responseHeaders[ resp.url ] += resp.statusLine + CRLF
 
   // console.log(("--------------Redirect Response Headers for "+resp.url+" --------------")
   for (var key in resp.responseHeaders) {
-    responseHeaders[resp.url] += resp.responseHeaders[key].name + ': ' + resp.responseHeaders[key].value + CRLF
+    responseHeaders[ resp.url ] += resp.responseHeaders[ key ].name + ': ' + resp.responseHeaders[ key ].value + CRLF
   }
 // console.log((responseHeaders[resp.url])
-}, { urls: ['http://*/*', 'https://*/*'], tabId: currentTabId}, ['responseHeaders'])
+}, { urls: [ 'http://*/*', 'https://*/*' ], tabId: currentTabId }, [ 'responseHeaders' ])
 
 /* ************************************************************
- 
+
  UTILITY FUNCTIONS
- 
-************************************************************ */
+
+ ************************************************************ */
 
 /**
- * From https://developer.mozilla.org/en-US/docs/Web/API/window.btoa 
+ * From https://developer.mozilla.org/en-US/docs/Web/API/window.btoa
  * Converts UTF-8 to base 64 data
-*/
+ */
 function utf8_to_b64 (str) {
   return window.btoa(unescape(encodeURIComponent(str)))
 }
 
 /**
- * From https://developer.mozilla.org/en-US/docs/Web/API/window.btoa 
+ * From https://developer.mozilla.org/en-US/docs/Web/API/window.btoa
  * Converts base 64 data to UTF-8
-*/
+ */
 function b64_to_utf8 (str) {
   return decodeURIComponent(escape(window.atob(str)))
 }
@@ -386,6 +396,6 @@ function b64_to_utf8 (str) {
 /**
  * UNUSED: A means of capturing any particular values that are only present in
  * this handler.
-*/
+ */
 chrome.webRequest.onResponseStarted.addListener(
-  function (details) {}, { urls: ['http://*/*', 'https://*/*']}, ['responseHeaders'])
+  function (details) {}, { urls: [ 'http://*/*', 'https://*/*' ] }, [ 'responseHeaders' ])

--- a/js/content.js
+++ b/js/content.js
@@ -12,7 +12,7 @@ function fetchImage (u) {
     delete imageUris[u]
     // console.log(("Fetched "+u+"  "+Object.keys(imageUris).length+" urls left to fetch")
     if (Object.keys(imageUris).length == 0) {
-      // console.log(("All image data collected");   
+      // console.log(("All image data collected");
     }
   }
 
@@ -47,8 +47,8 @@ chrome.extension.onConnect.addListener(function (port) {
           ret[u] = myString
           delete imgObjs[u]
 
-          // console.log("Ok, now postback image data"); 
-          // console.error(u); 
+          // console.log("Ok, now postback image data");
+          // console.error(u);
           var ohemefgee = {}
           ohemefgee[u] = stringUInt8Array
           chrome.storage.local.set(ohemefgee, function () {
@@ -59,7 +59,6 @@ chrome.extension.onConnect.addListener(function (port) {
           })
           // console.log(("- Image data in local storage for "+u)
           // port.postMessage({imageData: JSON.stringify(ret),method: "getImageDataRet",uri: u},function(e){})
-
         }
 
         xhr.onerror = function (e) {
@@ -73,13 +72,13 @@ chrome.extension.onConnect.addListener(function (port) {
       // get the image URIs from the DOM
       for (var image = 0; image < document.images.length; image++) {
         if (document.images[image].src.indexOf('data:') == -1) {
-          imgObjs[document.images[image].src] = 'foo'; // dummy data to-be-filled below programmatically
+          imgObjs[document.images[image].src] = 'foo' // dummy data to-be-filled below programmatically
         }
       }
       // get the image URIs embedded in CSS
       var imagesInCSS = getallBgimages()
       for (var imageInCSS = 0; imageInCSS < imagesInCSS.length; imageInCSS++) {
-        imgObjs[imagesInCSS[imageInCSS]] = 'foo'; // dummy data to-be-filled below programmatically
+        imgObjs[imagesInCSS[imageInCSS]] = 'foo' // dummy data to-be-filled below programmatically
       }
 
       var ret = {}
@@ -90,8 +89,7 @@ chrome.extension.onConnect.addListener(function (port) {
           fetchImage(uri)
         }
       }
-    }
-    else if (msg.method == 'getHTML') {
+    } else if (msg.method == 'getHTML') {
       // console.log(("about to post getHTML message")
       images = document.images
 
@@ -135,12 +133,12 @@ chrome.extension.onConnect.addListener(function (port) {
         }
       })
 
-      outlinksAddedRegistry = null; // reclaim space, since we no longer need this check given we're through building outlinks
+      outlinksAddedRegistry = null // reclaim space, since we no longer need this check given we're through building outlinks
 
       var imageURIs = []
       var imageBase64Data = []
       // image conversion code
-      // *********************************	
+      // *********************************
       // Convert images to something portal and text-y
       // *********************************
       // console.log("Converting image data, "+images.length+" to convert")
@@ -150,8 +148,9 @@ chrome.extension.onConnect.addListener(function (port) {
         // console.log((images[i].src)
         var image = images[i]
         if (!(image.src)) {
-          // console.log("Image "+i+" had no src. Continuing to encode the others"); 
-          continue;}
+          // console.log("Image "+i+" had no src. Continuing to encode the others");
+          continue
+        }
           // console.log(("About to convert image "+(i+1)+"/"+images.length+": "+images[i].src)
 
         var canvas = document.createElement('canvas')
@@ -166,7 +165,7 @@ chrome.extension.onConnect.addListener(function (port) {
       var imageDataSerialized = imageBase64Data.join('|||')
       var imageURIsSerialized = imageURIs.join('|||')
       localStorage['imagesInDOM'] = imageURIsSerialized
-      // *********************************	
+      // *********************************
       // Re-fetch CSS (limitation of webRequest, need to be able to get content on response, functionality unavailable, requires refetch)
       // *********************************
       // a better way to get all stylesheets but we cannot get them as text but instead an object with ruleslist
@@ -183,7 +182,7 @@ chrome.extension.onConnect.addListener(function (port) {
           styleSheetData.push(cssText)
         })
       }
-      // *********************************	
+      // *********************************
       // Re-fetch JS
       // *********************************
       var JSURLs = []
@@ -210,13 +209,13 @@ chrome.extension.onConnect.addListener(function (port) {
       // all of this nonsense just to get the doctype to prepend!
       var node = document.doctype
       var dtstr
-      if (!node) {dtstr = '';}else {
-        dtstr = '<!DOCTYPE '
-          + '' + node.name
-          + (node.publicId ? ' PUBLIC "' + node.publicId + '"' : '')
-          + (!node.publicId && node.systemId ? ' SYSTEM' : '')
-          + (node.systemId ? ' "' + node.systemId + '"' : '')
-          + '>'
+      if (!node) { dtstr = '' } else {
+        dtstr = '<!DOCTYPE ' +
+          '' + node.name +
+          (node.publicId ? ' PUBLIC "' + node.publicId + '"' : '') +
+          (!node.publicId && node.systemId ? ' SYSTEM' : '') +
+          (node.systemId ? ' "' + node.systemId + '"' : '') +
+          '>'
       }
 
       var domAsText = document.documentElement.outerHTML
@@ -234,7 +233,7 @@ chrome.extension.onConnect.addListener(function (port) {
       // console.log(("length before post: "+domAsText.length)
       port.postMessage({
         // html: dtstr + document.all[0].outerHTML, //document.all is non-standard
-        html: dtstr + domAsText, //   document.documentElement.outerHTML, 
+        html: dtstr + domAsText, //   document.documentElement.outerHTML,
         uris: imageURIsSerialized,
         data: imageDataSerialized,
         cssuris: cssURIsSerialized,
@@ -243,8 +242,8 @@ chrome.extension.onConnect.addListener(function (port) {
         jsdata: jsDataSerialized,
         outlinks: outlinksSerialized,
         method: msg.method
-      }); // communicate back to code.js ~130 with image data
-    }else {
+      }) // communicate back to code.js ~130 with image data
+    } else {
       // console.log(("Method unsupported in content.js: "+msg.method)
     }
   })

--- a/js/date.js
+++ b/js/date.js
@@ -5,443 +5,100 @@
  * License: Licensed under The MIT License. See license.txt and http://www.datejs.com/license/.
  * Website: http://www.datejs.com/ or http://www.coolite.com/datejs/
  */
-Date.CultureInfo = {name: 'en-US', englishName: 'English (United States)', nativeName: 'English (United States)', dayNames: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'], abbreviatedDayNames: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'], shortestDayNames: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'], firstLetterDayNames: ['S', 'M', 'T', 'W', 'T', 'F', 'S'], monthNames: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'], abbreviatedMonthNames: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'], amDesignator: 'AM', pmDesignator: 'PM', firstDayOfWeek: 0, twoDigitYearMax: 2029, dateElementOrder: 'mdy', formatPatterns: {shortDate: 'M/d/yyyy', longDate: 'dddd, MMMM dd, yyyy', shortTime: 'h:mm tt', longTime: 'h:mm:ss tt', fullDateTime: 'dddd, MMMM dd, yyyy h:mm:ss tt', sortableDateTime: 'yyyy-MM-ddTHH:mm:ss', universalSortableDateTime: 'yyyy-MM-dd HH:mm:ssZ', rfc1123: 'ddd, dd MMM yyyy HH:mm:ss GMT', monthDay: 'MMMM dd', yearMonth: 'MMMM, yyyy'}, regexPatterns: {jan: /^jan(uary)?/i, feb: /^feb(ruary)?/i, mar: /^mar(ch)?/i, apr: /^apr(il)?/i, may: /^may/i, jun: /^jun(e)?/i, jul: /^jul(y)?/i, aug: /^aug(ust)?/i, sep: /^sep(t(ember)?)?/i, oct: /^oct(ober)?/i, nov: /^nov(ember)?/i, dec: /^dec(ember)?/i, sun: /^su(n(day)?)?/i, mon: /^mo(n(day)?)?/i, tue: /^tu(e(s(day)?)?)?/i, wed: /^we(d(nesday)?)?/i, thu: /^th(u(r(s(day)?)?)?)?/i, fri: /^fr(i(day)?)?/i, sat: /^sa(t(urday)?)?/i, future: /^next/i, past: /^last|past|prev(ious)?/i, add: /^(\+|after|from)/i, subtract: /^(\-|before|ago)/i, yesterday: /^yesterday/i, today: /^t(oday)?/i, tomorrow: /^tomorrow/i, now: /^n(ow)?/i, millisecond: /^ms|milli(second)?s?/i, second: /^sec(ond)?s?/i, minute: /^min(ute)?s?/i, hour: /^h(ou)?rs?/i, week: /^w(ee)?k/i, month: /^m(o(nth)?s?)?/i, day: /^d(ays?)?/i, year: /^y((ea)?rs?)?/i, shortMeridian: /^(a|p)/i, longMeridian: /^(a\.?m?\.?|p\.?m?\.?)/i, timezone: /^((e(s|d)t|c(s|d)t|m(s|d)t|p(s|d)t)|((gmt)?\s*(\+|\-)\s*\d\d\d\d?)|gmt)/i, ordinalSuffix: /^\s*(st|nd|rd|th)/i, timeContext: /^\s*(\:|a|p)/i}, abbreviatedTimeZoneStandard: {GMT: '-000', EST: '-0400', CST: '-0500', MST: '-0600', PST: '-0700'}, abbreviatedTimeZoneDST: {GMT: '-000', EDT: '-0500', CDT: '-0600', MDT: '-0700', PDT: '-0800'}}
-Date.getMonthNumberFromName = function (name) {
-  var n = Date.CultureInfo.monthNames, m = Date.CultureInfo.abbreviatedMonthNames, s = name.toLowerCase()
-  for (var i = 0; i < n.length; i++) { if (n[i].toLowerCase() == s || m[i].toLowerCase() == s) { return i } }
-  return -1
-}; Date.getDayNumberFromName = function (name) {
-  var n = Date.CultureInfo.dayNames, m = Date.CultureInfo.abbreviatedDayNames, o = Date.CultureInfo.shortestDayNames, s = name.toLowerCase()
-  for (var i = 0; i < n.length; i++) { if (n[i].toLowerCase() == s || m[i].toLowerCase() == s) { return i } }
-  return -1
-}; Date.isLeapYear = function (year) { return (((year % 4 === 0) && (year % 100 !== 0)) || (year % 400 === 0)) }; Date.getDaysInMonth = function (year, month) { return [31, (Date.isLeapYear(year) ? 29 : 28), 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month] }; Date.getTimezoneOffset = function (s, dst) { return (dst || false) ? Date.CultureInfo.abbreviatedTimeZoneDST[s.toUpperCase()] : Date.CultureInfo.abbreviatedTimeZoneStandard[s.toUpperCase()] }; Date.getTimezoneAbbreviation = function (offset, dst) {
-  var n = (dst || false) ? Date.CultureInfo.abbreviatedTimeZoneDST : Date.CultureInfo.abbreviatedTimeZoneStandard, p
-  for (p in n) { if (n[p] === offset) { return p } }
-  return null
-}; Date.prototype.clone = function () { return new Date(this.getTime()) }; Date.prototype.compareTo = function (date) {
-  if (isNaN(this)) { throw new Error(this) }
-  if (date instanceof Date && !isNaN(date)) { return (this > date) ? 1 : (this < date) ? -1 : 0 } else { throw new TypeError(date) }
-}; Date.prototype.equals = function (date) { return (this.compareTo(date) === 0) }; Date.prototype.between = function (start, end) {
-  var t = this.getTime()
-  return t >= start.getTime() && t <= end.getTime()
-}; Date.prototype.addMilliseconds = function (value) { this.setMilliseconds(this.getMilliseconds() + value); return this }; Date.prototype.addSeconds = function (value) { return this.addMilliseconds(value * 1000) }; Date.prototype.addMinutes = function (value) { return this.addMilliseconds(value * 60000) }; Date.prototype.addHours = function (value) { return this.addMilliseconds(value * 3600000) }; Date.prototype.addDays = function (value) { return this.addMilliseconds(value * 86400000) }; Date.prototype.addWeeks = function (value) { return this.addMilliseconds(value * 604800000) }; Date.prototype.addMonths = function (value) {
-  var n = this.getDate()
-  this.setDate(1); this.setMonth(this.getMonth() + value); this.setDate(Math.min(n, this.getDaysInMonth())); return this
-}; Date.prototype.addYears = function (value) { return this.addMonths(value * 12) }; Date.prototype.add = function (config) {
-  if (typeof config === 'number') { this._orient = config; return this }
-  var x = config
-  if (x.millisecond || x.milliseconds) { this.addMilliseconds(x.millisecond || x.milliseconds) }
-  if (x.second || x.seconds) { this.addSeconds(x.second || x.seconds) }
-  if (x.minute || x.minutes) { this.addMinutes(x.minute || x.minutes) }
-  if (x.hour || x.hours) { this.addHours(x.hour || x.hours) }
-  if (x.month || x.months) { this.addMonths(x.month || x.months) }
-  if (x.year || x.years) { this.addYears(x.year || x.years) }
-  if (x.day || x.days) { this.addDays(x.day || x.days) }
-  return this
-}; Date._validate = function (value, min, max, name) {
-  if (typeof value !== 'number') { throw new TypeError(value + ' is not a Number.') } else if (value < min || value > max) { throw new RangeError(value + ' is not a valid value for ' + name + '.') }
-  return true
-}; Date.validateMillisecond = function (n) { return Date._validate(n, 0, 999, 'milliseconds') }; Date.validateSecond = function (n) { return Date._validate(n, 0, 59, 'seconds') }; Date.validateMinute = function (n) { return Date._validate(n, 0, 59, 'minutes') }; Date.validateHour = function (n) { return Date._validate(n, 0, 23, 'hours') }; Date.validateDay = function (n, year, month) { return Date._validate(n, 1, Date.getDaysInMonth(year, month), 'days') }; Date.validateMonth = function (n) { return Date._validate(n, 0, 11, 'months') }; Date.validateYear = function (n) { return Date._validate(n, 1, 9999, 'seconds') }; Date.prototype.set = function (config) {
-  var x = config
-  if (!x.millisecond && x.millisecond !== 0) { x.millisecond = -1 }
-  if (!x.second && x.second !== 0) { x.second = -1 }
-  if (!x.minute && x.minute !== 0) { x.minute = -1 }
-  if (!x.hour && x.hour !== 0) { x.hour = -1 }
-  if (!x.day && x.day !== 0) { x.day = -1 }
-  if (!x.month && x.month !== 0) { x.month = -1 }
-  if (!x.year && x.year !== 0) { x.year = -1 }
-  if (x.millisecond != -1 && Date.validateMillisecond(x.millisecond)) { this.addMilliseconds(x.millisecond - this.getMilliseconds()) }
-  if (x.second != -1 && Date.validateSecond(x.second)) { this.addSeconds(x.second - this.getSeconds()) }
-  if (x.minute != -1 && Date.validateMinute(x.minute)) { this.addMinutes(x.minute - this.getMinutes()) }
-  if (x.hour != -1 && Date.validateHour(x.hour)) { this.addHours(x.hour - this.getHours()) }
-  if (x.month !== -1 && Date.validateMonth(x.month)) { this.addMonths(x.month - this.getMonth()) }
-  if (x.year != -1 && Date.validateYear(x.year)) { this.addYears(x.year - this.getFullYear()) }
-  if (x.day != -1 && Date.validateDay(x.day, this.getFullYear(), this.getMonth())) { this.addDays(x.day - this.getDate()) }
-  if (x.timezone) { this.setTimezone(x.timezone) }
-  if (x.timezoneOffset) { this.setTimezoneOffset(x.timezoneOffset) }
-  return this
-}; Date.prototype.clearTime = function () { this.setHours(0); this.setMinutes(0); this.setSeconds(0); this.setMilliseconds(0); return this }; Date.prototype.isLeapYear = function () {
-  var y = this.getFullYear()
-  return (((y % 4 === 0) && (y % 100 !== 0)) || (y % 400 === 0))
-}; Date.prototype.isWeekday = function () { return !(this.is().sat() || this.is().sun()) }; Date.prototype.getDaysInMonth = function () { return Date.getDaysInMonth(this.getFullYear(), this.getMonth()) }; Date.prototype.moveToFirstDayOfMonth = function () { return this.set({day: 1}) }; Date.prototype.moveToLastDayOfMonth = function () { return this.set({day: this.getDaysInMonth()}) }; Date.prototype.moveToDayOfWeek = function (day, orient) {
-  var diff = (day - this.getDay() + 7 * (orient || +1)) % 7
-  return this.addDays((diff === 0) ? diff += 7 * (orient || +1) : diff)
-}; Date.prototype.moveToMonth = function (month, orient) {
-  var diff = (month - this.getMonth() + 12 * (orient || +1)) % 12
-  return this.addMonths((diff === 0) ? diff += 12 * (orient || +1) : diff)
-}; Date.prototype.getDayOfYear = function () { return Math.floor((this - new Date(this.getFullYear(), 0, 1)) / 86400000) }; Date.prototype.getWeekOfYear = function (firstDayOfWeek) {
-  var y = this.getFullYear(), m = this.getMonth(), d = this.getDate()
-  var dow = firstDayOfWeek || Date.CultureInfo.firstDayOfWeek
-  var offset = 7 + 1 - new Date(y, 0, 1).getDay()
-  if (offset == 8) { offset = 1 }
-  var daynum = ((Date.UTC(y, m, d, 0, 0, 0) - Date.UTC(y, 0, 1, 0, 0, 0)) / 86400000) + 1
-  var w = Math.floor((daynum - offset + 7) / 7)
-  if (w === dow) {
-    y--; var prevOffset = 7 + 1 - new Date(y, 0, 1).getDay()
-    if (prevOffset == 2 || prevOffset == 8) { w = 53 } else { w = 52 }
-  }
-  return w
-}; Date.prototype.isDST = function () { console.log('isDST'); return this.toString().match(/(E|C|M|P)(S|D)T/)[2] == 'D' }; Date.prototype.getTimezone = function () { return Date.getTimezoneAbbreviation(this.getUTCOffset, this.isDST()) }; Date.prototype.setTimezoneOffset = function (s) {
-  var here = this.getTimezoneOffset(), there = Number(s) * -6 / 10
-  this.addMinutes(there - here); return this
-}; Date.prototype.setTimezone = function (s) { return this.setTimezoneOffset(Date.getTimezoneOffset(s)) }; Date.prototype.getUTCOffset = function () {
-  var n = this.getTimezoneOffset() * -10 / 6, r
-  if (n < 0) { r = (n - 10000).toString(); return r[0] + r.substr(2) } else { r = (n + 10000).toString(); return '+' + r.substr(1) }
-}; Date.prototype.getDayName = function (abbrev) { return abbrev ? Date.CultureInfo.abbreviatedDayNames[this.getDay()] : Date.CultureInfo.dayNames[this.getDay()] }; Date.prototype.getMonthName = function (abbrev) { return abbrev ? Date.CultureInfo.abbreviatedMonthNames[this.getMonth()] : Date.CultureInfo.monthNames[this.getMonth()] }; Date.prototype._toString = Date.prototype.toString; Date.prototype.toString = function (format) {
-  var self = this
-  var p = function p (s) { return (s.toString().length == 1) ? '0' + s : s }
-  return format ? format.replace(/dd?d?d?|MM?M?M?|yy?y?y?|hh?|HH?|mm?|ss?|tt?|zz?z?/g, function (format) {
-    switch (format) {
-      case 'hh':
-        return p(self.getHours() < 13 ? self.getHours() : (self.getHours() - 12)); case 'h':
-        return self.getHours() < 13 ? self.getHours() : (self.getHours() - 12); case 'HH':
-        return p(self.getHours()); case 'H':
-        return self.getHours(); case 'mm':
-        return p(self.getMinutes()); case 'm':
-        return self.getMinutes(); case 'ss':
-        return p(self.getSeconds()); case 's':
-        return self.getSeconds(); case 'yyyy':
-        return self.getFullYear(); case 'yy':
-        return self.getFullYear().toString().substring(2, 4); case 'dddd':
-        return self.getDayName(); case 'ddd':
-        return self.getDayName(true); case 'dd':
-        return p(self.getDate()); case 'd':
-        return self.getDate().toString(); case 'MMMM':
-        return self.getMonthName(); case 'MMM':
-        return self.getMonthName(true); case 'MM':
-        return p((self.getMonth() + 1)); case 'M':
-        return self.getMonth() + 1; case 't':
-        return self.getHours() < 12 ? Date.CultureInfo.amDesignator.substring(0, 1) : Date.CultureInfo.pmDesignator.substring(0, 1); case 'tt':
-        return self.getHours() < 12 ? Date.CultureInfo.amDesignator : Date.CultureInfo.pmDesignator; case 'zzz':
-      case 'zz':
-      case 'z':
-        return ''
-    }
-  }) : this._toString()
-}
-Date.now = function () { return new Date() }; Date.today = function () { return Date.now().clearTime() }; Date.prototype._orient = +1; Date.prototype.next = function () { this._orient = +1; return this }; Date.prototype.last = Date.prototype.prev = Date.prototype.previous = function () { this._orient = -1; return this }; Date.prototype._is = false; Date.prototype.is = function () { this._is = true; return this }; Number.prototype._dateElement = 'day'; Number.prototype.fromNow = function () {
-  var c = {}
-  c[this._dateElement] = this; return Date.now().add(c)
-}; Number.prototype.ago = function () {
-  var c = {}
-  c[this._dateElement] = this * -1; return Date.now().add(c)
-}
-;(function () {
-  var $D = Date.prototype, $N = Number.prototype
-  var dx = ('sunday monday tuesday wednesday thursday friday saturday').split(/\s/), mx = ('january february march april may june july august september october november december').split(/\s/), px = ('Millisecond Second Minute Hour Day Week Month Year').split(/\s/), de
-  var df = function (n) {
-    return function () {
-      if (this._is) { this._is = false; return this.getDay() == n }
-      return this.moveToDayOfWeek(n, this._orient)
-    }
-  }
-  for (var i = 0; i < dx.length; i++) { $D[dx[i]] = $D[dx[i].substring(0, 3)] = df(i) }
-  var mf = function (n) {
-    return function () {
-      if (this._is) { this._is = false; return this.getMonth() === n }
-      return this.moveToMonth(n, this._orient)
-    }
-  }
-  for (var j = 0; j < mx.length; j++) { $D[mx[j]] = $D[mx[j].substring(0, 3)] = mf(j) }
-  var ef = function (j) {
-    return function () {
-      if (j.substring(j.length - 1) != 's') { j += 's' }
-      return this['add' + j](this._orient)
-    }
-  }
-  var nf = function (n) { return function () { this._dateElement = n; return this } }
-  for (var k = 0; k < px.length; k++) { de = px[k].toLowerCase(); $D[de] = $D[de + 's'] = ef(px[k]); $N[de] = $N[de + 's'] = nf(de) }
-}()); Date.prototype.toJSONString = function () { return this.toString('yyyy-MM-ddThh:mm:ssZ') }; Date.prototype.toShortDateString = function () { return this.toString(Date.CultureInfo.formatPatterns.shortDatePattern) }; Date.prototype.toLongDateString = function () { return this.toString(Date.CultureInfo.formatPatterns.longDatePattern) }; Date.prototype.toShortTimeString = function () { return this.toString(Date.CultureInfo.formatPatterns.shortTimePattern) }; Date.prototype.toLongTimeString = function () { return this.toString(Date.CultureInfo.formatPatterns.longTimePattern) }; Date.prototype.getOrdinal = (function () {
-  switch (this.getDate()) {
-    case 1:
-    case 21:
-    case 31:
-      return 'st'; case 2:
-    case 22:
-      return 'nd'; case 3:
-    case 23:
-      return 'rd'; default:
-      return 'th'
-  }
-}(function () {
-  Date.Parsing = {Exception: function (s) { this.message = "Parse error at '" + s.substring(0, 10) + " ...'" }}; var $P = Date.Parsing
-  var _ = $P.Operators = {rtoken: function (r) {
-    return function (s) {
-      var mx = s.match(r)
-      if (mx) { return ([mx[0], s.substring(mx[0].length)]) } else { throw new $P.Exception(s) }
-    }
-  },
-    token: function (s) { return function (s) { return _.rtoken(new RegExp('^\s*' + s + '\s*'))(s) } },
-    stoken: function (s) { return _.rtoken(new RegExp('^' + s)) },
-    until: function (p) {
-      return function (s) {
-        var qx = [], rx = null
-        while (s.length) {
-          try { rx = p.call(this, s) } catch (e) { qx.push(rx[0]); s = rx[1]; continue }
-          break
-        }
-        return [qx, s]
-      }
-    },
-    many: function (p) {
-      return function (s) {
-        var rx = [], r = null
-        while (s.length) {
-          try { r = p.call(this, s) } catch (e) { return [rx, s] }
-          rx.push(r[0]); s = r[1]
-        }
-        return [rx, s]
-      }
-    },
-    optional: function (p) {
-      return function (s) {
-        var r = null
-        try { r = p.call(this, s) } catch (e) { return [null, s] }
-        return [r[0], r[1]]
-      }
-    },
-    not: function (p) {
-      return function (s) {
-        try { p.call(this, s) } catch (e) { return [null, s] }
-        throw new $P.Exception(s)
-      }
-    },
-    ignore: function (p) {
-      return p ? function (s) {
-        var r = null
-        r = p.call(this, s); return [null, r[1]]
-      } : null
-    },
-    product: function () {
-      var px = arguments[0], qx = Array.prototype.slice.call(arguments, 1), rx = []
-      for (var i = 0; i < px.length; i++) { rx.push(_.each(px[i], qx)) }
-      return rx
-    },
-    cache: function (rule) {
-      var cache = {}, r = null
-      return function (s) {
-        try { r = cache[s] = (cache[s] || rule.call(this, s)) } catch (e) { r = cache[s] = e }
-        if (r instanceof $P.Exception) { throw r } else { return r }
-      }
-    },
-    any: function () {
-      var px = arguments
-      return function (s) {
-        var r = null
-        for (var i = 0; i < px.length; i++) {
-          if (px[i] == null) { continue }
-          try { r = (px[i].call(this, s)) } catch (e) { r = null }
-          if (r) { return r }
-        }
-        throw new $P.Exception(s)
-      }
-    },
-    each: function () {
-      var px = arguments
-      return function (s) {
-        var rx = [], r = null
-        for (var i = 0; i < px.length; i++) {
-          if (px[i] == null) { continue }
-          try { r = (px[i].call(this, s)) } catch (e) { throw new $P.Exception(s) }
-          rx.push(r[0]); s = r[1]
-        }
-        return [rx, s]
-      }
-    },
-    all: function () {
-      var px = arguments, _ = _
-      return _.each(_.optional(px))
-    },
-    sequence: function (px, d, c) {
-      d = d || _.rtoken(/^\s*/); c = c || null; if (px.length == 1) { return px[0] }
-      return function (s) {
-        var r = null, q = null
-        var rx = []
-        for (var i = 0; i < px.length; i++) {
-          try { r = px[i].call(this, s) } catch (e) { break }
-          rx.push(r[0]); try { q = d.call(this, r[1]) } catch (ex) { q = null; break }
-          s = q[1]
-        }
-        if (!r) { throw new $P.Exception(s) }
-        if (q) { throw new $P.Exception(q[1]) }
-        if (c) { try { r = c.call(this, r[1]) } catch (ey) { throw new $P.Exception(r[1]) } }
-        return [rx, (r ? r[1] : s)]
-      }
-    },
-    between: function (d1, p, d2) {
-      d2 = d2 || d1; var _fn = _.each(_.ignore(d1), p, _.ignore(d2))
-      return function (s) {
-        var rx = _fn.call(this, s)
-        return [[rx[0][0], r[0][2]], rx[1]]
-      }
-    },
-    list: function (p, d, c) { d = d || _.rtoken(/^\s*/); c = c || null; return (p instanceof Array ? _.each(_.product(p.slice(0, -1), _.ignore(d)), p.slice(-1), _.ignore(c)) : _.each(_.many(_.each(p, _.ignore(d))), px, _.ignore(c))) },
-    set: function (px, d, c) {
-      d = d || _.rtoken(/^\s*/); c = c || null; return function (s) {
-        var r = null, p = null, q = null, rx = null, best = [[], s], last = false
-        for (var i = 0; i < px.length; i++) {
-          q = null; p = null; r = null; last = (px.length == 1); try { r = px[i].call(this, s) } catch (e) { continue }
-          rx = [[r[0]], r[1]]; if (r[1].length > 0 && !last) { try { q = d.call(this, r[1]) } catch (ex) { last = true } } else { last = true }
-          if (!last && q[1].length === 0) { last = true }
-          if (!last) {
-            var qx = []
-            for (var j = 0; j < px.length; j++) { if (i != j) { qx.push(px[j]) } }
-            p = _.set(qx, d).call(this, q[1]); if (p[0].length > 0) { rx[0] = rx[0].concat(p[0]); rx[1] = p[1] }
-          }
-          if (rx[1].length < best[1].length) { best = rx }
-          if (best[1].length === 0) { break }
-        }
-        if (best[0].length === 0) { return best }
-        if (c) {
-          try { q = c.call(this, best[1]) } catch (ey) { throw new $P.Exception(best[1]) }
-          best[1] = q[1]
-        }
-        return best
-      }
-    },
-    forward: function (gr, fname) { return function (s) { return gr[fname].call(this, s) } },
-    replace: function (rule, repl) {
-      return function (s) {
-        var r = rule.call(this, s)
-        return [repl, r[1]]
-      }
-    },
-    process: function (rule, fn) {
-      return function (s) {
-        var r = rule.call(this, s)
-        return [fn.call(this, r[0]), r[1]]
-      }
-    },
-    min: function (min, rule) {
-      return function (s) {
-        var rx = rule.call(this, s)
-        if (rx[0].length < min) { throw new $P.Exception(s) }
-        return rx
-      }
-    }}
-  var _generator = function (op) {
-    return function () {
-      var args = null, rx = []
-      if (arguments.length > 1) { args = Array.prototype.slice.call(arguments) } else if (arguments[0] instanceof Array) { args = arguments[0] }
-      if (args) { for (var i = 0, px = args.shift(); i < px.length; i++) { args.unshift(px[i]); rx.push(op.apply(null, args)); args.shift(); return rx } } else { return op.apply(null, arguments) }
-    }
-  }
-  var gx = 'optional not ignore cache'.split(/\s/)
-  for (var i = 0; i < gx.length; i++) { _[gx[i]] = _generator(_[gx[i]]) }
-  var _vector = function (op) { return function () { if (arguments[0] instanceof Array) { return op.apply(null, arguments[0]) } else { return op.apply(null, arguments) } } }
-  var vx = 'each any all'.split(/\s/)
-  for (var j = 0; j < vx.length; j++) { _[vx[j]] = _vector(_[vx[j]]) }
-}()))
-;(function () {
-  var flattenAndCompact = function (ax) {
-    var rx = []
-    for (var i = 0; i < ax.length; i++) { if (ax[i] instanceof Array) { rx = rx.concat(flattenAndCompact(ax[i])) } else { if (ax[i]) { rx.push(ax[i]) } } }
-    return rx
-  }
-  Date.Grammar = {}; Date.Translator = {hour: function (s) { return function () { this.hour = Number(s) } },
-    minute: function (s) { return function () { this.minute = Number(s) } },
-    second: function (s) { return function () { this.second = Number(s) } },
-    meridian: function (s) { return function () { this.meridian = s.slice(0, 1).toLowerCase() } },
-    timezone: function (s) {
-      return function () {
-        var n = s.replace(/[^\d\+\-]/g, '')
-        if (n.length) { this.timezoneOffset = Number(n) } else { this.timezone = s.toLowerCase() }
-      }
-    },
-    day: function (x) {
-      var s = x[0]
-      return function () { this.day = Number(s.match(/\d+/)[0]) }
-    },
-    month: function (s) { return function () { this.month = ((s.length == 3) ? Date.getMonthNumberFromName(s) : (Number(s) - 1)) } },
-    year: function (s) {
-      return function () {
-        var n = Number(s)
-        this.year = ((s.length > 2) ? n : (n + (((n + 2000) < Date.CultureInfo.twoDigitYearMax) ? 2000 : 1900)))
-      }
-    },
-    rday: function (s) {
-      return function () {
-        switch (s) {
-          case 'yesterday':
-            this.days = -1
-            break; case 'tomorrow':
-            this.days = 1
-            break; case 'today':
-            this.days = 0
-            break; case 'now':
-            this.days = 0; this.now = true
-            break
-        }
-      }
-    },
-    finishExact: function (x) {
-      x = (x instanceof Array) ? x : [x]; var now = new Date()
-      this.year = now.getFullYear(); this.month = now.getMonth(); this.day = 1; this.hour = 0; this.minute = 0; this.second = 0; for (var i = 0; i < x.length; i++) { if (x[i]) { x[i].call(this) } }
-      this.hour = (this.meridian == 'p' && this.hour < 13) ? this.hour + 12 : this.hour; if (this.day > Date.getDaysInMonth(this.year, this.month)) { throw new RangeError(this.day + ' is not a valid value for days.') }
-      var r = new Date(this.year, this.month, this.day, this.hour, this.minute, this.second)
-      if (this.timezone) { r.set({timezone: this.timezone}) } else if (this.timezoneOffset) { r.set({timezoneOffset: this.timezoneOffset}) }
-      return r
-    },
-    finish: function (x) {
-      x = (x instanceof Array) ? flattenAndCompact(x) : [x]; if (x.length === 0) { return null }
-      for (var i = 0; i < x.length; i++) { if (typeof x[i] === 'function') { x[i].call(this) } }
-      if (this.now) { return new Date() }
-      var today = Date.today()
-      var method = null
-      var expression = !!(this.days != null || this.orient || this.operator)
-      if (expression) {
-        var gap, mod, orient
-        orient = ((this.orient == 'past' || this.operator == 'subtract') ? -1 : 1); if (this.weekday) { this.unit = 'day'; gap = (Date.getDayNumberFromName(this.weekday) - today.getDay()); mod = 7; this.days = gap ? ((gap + (orient * mod)) % mod) : (orient * mod) }
-        if (this.month) { this.unit = 'month'; gap = (this.month - today.getMonth()); mod = 12; this.months = gap ? ((gap + (orient * mod)) % mod) : (orient * mod); this.month = null }
-        if (!this.unit) { this.unit = 'day' }
-        if (this[this.unit + 's'] == null || this.operator != null) {
-          if (!this.value) { this.value = 1 }
-          if (this.unit == 'week') { this.unit = 'day'; this.value = this.value * 7 }
-          this[this.unit + 's'] = this.value * orient
-        }
-        return today.add(this)
-      } else {
-        if (this.meridian && this.hour) { this.hour = (this.hour < 13 && this.meridian == 'p') ? this.hour + 12 : this.hour }
-        if (this.weekday && !this.day) { this.day = (today.addDays((Date.getDayNumberFromName(this.weekday) - today.getDay()))).getDate() }
-        if (this.month && !this.day) { this.day = 1 }
-        return today.set(this)
-      }
-    }}; var _ = Date.Parsing.Operators, g = Date.Grammar, t = Date.Translator, _fn
-  g.datePartDelimiter = _.rtoken(/^([\s\-\.\,\/\x27]+)/); g.timePartDelimiter = _.stoken(':'); g.whiteSpace = _.rtoken(/^\s*/); g.generalDelimiter = _.rtoken(/^(([\s\,]|at|on)+)/); var _C = {}
-  g.ctoken = function (keys) {
-    var fn = _C[keys]
-    if (!fn) {
-      var c = Date.CultureInfo.regexPatterns
-      var kx = keys.split(/\s+/), px = []
-      for (var i = 0; i < kx.length; i++) { px.push(_.replace(_.rtoken(c[kx[i]]), kx[i])) }
-      fn = _C[keys] = _.any.apply(null, px)
-    }
-    return fn
-  }; g.ctoken2 = function (key) { return _.rtoken(Date.CultureInfo.regexPatterns[key]) }; g.h = _.cache(_.process(_.rtoken(/^(0[0-9]|1[0-2]|[1-9])/), t.hour)); g.hh = _.cache(_.process(_.rtoken(/^(0[0-9]|1[0-2])/), t.hour)); g.H = _.cache(_.process(_.rtoken(/^([0-1][0-9]|2[0-3]|[0-9])/), t.hour)); g.HH = _.cache(_.process(_.rtoken(/^([0-1][0-9]|2[0-3])/), t.hour)); g.m = _.cache(_.process(_.rtoken(/^([0-5][0-9]|[0-9])/), t.minute)); g.mm = _.cache(_.process(_.rtoken(/^[0-5][0-9]/), t.minute)); g.s = _.cache(_.process(_.rtoken(/^([0-5][0-9]|[0-9])/), t.second)); g.ss = _.cache(_.process(_.rtoken(/^[0-5][0-9]/), t.second)); g.hms = _.cache(_.sequence([g.H, g.mm, g.ss], g.timePartDelimiter)); g.t = _.cache(_.process(g.ctoken2('shortMeridian'), t.meridian)); g.tt = _.cache(_.process(g.ctoken2('longMeridian'), t.meridian)); g.z = _.cache(_.process(_.rtoken(/^(\+|\-)?\s*\d\d\d\d?/), t.timezone)); g.zz = _.cache(_.process(_.rtoken(/^(\+|\-)\s*\d\d\d\d/), t.timezone)); g.zzz = _.cache(_.process(g.ctoken2('timezone'), t.timezone)); g.timeSuffix = _.each(_.ignore(g.whiteSpace), _.set([g.tt, g.zzz])); g.time = _.each(_.optional(_.ignore(_.stoken('T'))), g.hms, g.timeSuffix); g.d = _.cache(_.process(_.each(_.rtoken(/^([0-2]\d|3[0-1]|\d)/), _.optional(g.ctoken2('ordinalSuffix'))), t.day)); g.dd = _.cache(_.process(_.each(_.rtoken(/^([0-2]\d|3[0-1])/), _.optional(g.ctoken2('ordinalSuffix'))), t.day)); g.ddd = g.dddd = _.cache(_.process(g.ctoken('sun mon tue wed thu fri sat'), function (s) { return function () { this.weekday = s } })); g.M = _.cache(_.process(_.rtoken(/^(1[0-2]|0\d|\d)/), t.month)); g.MM = _.cache(_.process(_.rtoken(/^(1[0-2]|0\d)/), t.month)); g.MMM = g.MMMM = _.cache(_.process(g.ctoken('jan feb mar apr may jun jul aug sep oct nov dec'), t.month)); g.y = _.cache(_.process(_.rtoken(/^(\d\d?)/), t.year)); g.yy = _.cache(_.process(_.rtoken(/^(\d\d)/), t.year)); g.yyy = _.cache(_.process(_.rtoken(/^(\d\d?\d?\d?)/), t.year)); g.yyyy = _.cache(_.process(_.rtoken(/^(\d\d\d\d)/), t.year)); _fn = function () { return _.each(_.any.apply(null, arguments), _.not(g.ctoken2('timeContext'))) }; g.day = _fn(g.d, g.dd); g.month = _fn(g.M, g.MMM); g.year = _fn(g.yyyy, g.yy); g.orientation = _.process(g.ctoken('past future'), function (s) { return function () { this.orient = s } }); g.operator = _.process(g.ctoken('add subtract'), function (s) { return function () { this.operator = s } }); g.rday = _.process(g.ctoken('yesterday tomorrow today now'), t.rday); g.unit = _.process(g.ctoken('minute hour day week month year'), function (s) { return function () { this.unit = s } }); g.value = _.process(_.rtoken(/^\d\d?(st|nd|rd|th)?/), function (s) { return function () { this.value = s.replace(/\D/g, '') } }); g.expression = _.set([g.rday, g.operator, g.value, g.unit, g.orientation, g.ddd, g.MMM]); _fn = function () { return _.set(arguments, g.datePartDelimiter) }; g.mdy = _fn(g.ddd, g.month, g.day, g.year); g.ymd = _fn(g.ddd, g.year, g.month, g.day); g.dmy = _fn(g.ddd, g.day, g.month, g.year); g.date = function (s) { return ((g[Date.CultureInfo.dateElementOrder] || g.mdy).call(this, s)) }; g.format = _.process(_.many(_.any(_.process(_.rtoken(/^(dd?d?d?|MM?M?M?|yy?y?y?|hh?|HH?|mm?|ss?|tt?|zz?z?)/), function (fmt) { if (g[fmt]) { return g[fmt] } else { throw Date.Parsing.Exception(fmt) } }), _.process(_.rtoken(/^[^dMyhHmstz]+/), function (s) { return _.ignore(_.stoken(s)) }))), function (rules) { return _.process(_.each.apply(null, rules), t.finishExact) }); var _F = {}
-  var _get = function (f) { return _F[f] = (_F[f] || g.format(f)[0]) }
-  g.formats = function (fx) {
-    if (fx instanceof Array) {
-      var rx = []
-      for (var i = 0; i < fx.length; i++) { rx.push(_get(fx[i])) }
-      return _.any.apply(null, rx)
-    } else { return _get(fx) }
-  }; g._formats = g.formats(['yyyy-MM-ddTHH:mm:ss', 'ddd, MMM dd, yyyy H:mm:ss tt', 'ddd MMM d yyyy HH:mm:ss zzz', 'd']); g._start = _.process(_.set([g.date, g.time, g.expression], g.generalDelimiter, g.whiteSpace), t.finish); g.start = function (s) {
-    try {
-      var r = g._formats.call({}, s)
-      if (r[1].length === 0) { return r }
-    } catch (e) {}
-    return g._start.call({}, s)
-  }
-}()); Date._parse = Date.parse; Date.parse = function (s) {
-  var r = null
-  if (!s) { return null }
-  try { r = Date.Grammar.start.call({}, s) } catch (e) { return null }
-  return ((r[1].length === 0) ? r[0] : null)
-}; Date.getParseFunction = function (fx) {
-  var fn = Date.Grammar.formats(fx)
-  return function (s) {
-    var r = null
-    try { r = fn.call({}, s) } catch (e) { return null }
-    return ((r[1].length === 0) ? r[0] : null)
-  }
-}; Date.parseExact = function (s, fx) { return Date.getParseFunction(fx)(s) }
+Date.CultureInfo={name:"en-US",englishName:"English (United States)",nativeName:"English (United States)",dayNames:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],abbreviatedDayNames:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],shortestDayNames:["Su","Mo","Tu","We","Th","Fr","Sa"],firstLetterDayNames:["S","M","T","W","T","F","S"],monthNames:["January","February","March","April","May","June","July","August","September","October","November","December"],abbreviatedMonthNames:["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],amDesignator:"AM",pmDesignator:"PM",firstDayOfWeek:0,twoDigitYearMax:2029,dateElementOrder:"mdy",formatPatterns:{shortDate:"M/d/yyyy",longDate:"dddd, MMMM dd, yyyy",shortTime:"h:mm tt",longTime:"h:mm:ss tt",fullDateTime:"dddd, MMMM dd, yyyy h:mm:ss tt",sortableDateTime:"yyyy-MM-ddTHH:mm:ss",universalSortableDateTime:"yyyy-MM-dd HH:mm:ssZ",rfc1123:"ddd, dd MMM yyyy HH:mm:ss GMT",monthDay:"MMMM dd",yearMonth:"MMMM, yyyy"},regexPatterns:{jan:/^jan(uary)?/i,feb:/^feb(ruary)?/i,mar:/^mar(ch)?/i,apr:/^apr(il)?/i,may:/^may/i,jun:/^jun(e)?/i,jul:/^jul(y)?/i,aug:/^aug(ust)?/i,sep:/^sep(t(ember)?)?/i,oct:/^oct(ober)?/i,nov:/^nov(ember)?/i,dec:/^dec(ember)?/i,sun:/^su(n(day)?)?/i,mon:/^mo(n(day)?)?/i,tue:/^tu(e(s(day)?)?)?/i,wed:/^we(d(nesday)?)?/i,thu:/^th(u(r(s(day)?)?)?)?/i,fri:/^fr(i(day)?)?/i,sat:/^sa(t(urday)?)?/i,future:/^next/i,past:/^last|past|prev(ious)?/i,add:/^(\+|after|from)/i,subtract:/^(\-|before|ago)/i,yesterday:/^yesterday/i,today:/^t(oday)?/i,tomorrow:/^tomorrow/i,now:/^n(ow)?/i,millisecond:/^ms|milli(second)?s?/i,second:/^sec(ond)?s?/i,minute:/^min(ute)?s?/i,hour:/^h(ou)?rs?/i,week:/^w(ee)?k/i,month:/^m(o(nth)?s?)?/i,day:/^d(ays?)?/i,year:/^y((ea)?rs?)?/i,shortMeridian:/^(a|p)/i,longMeridian:/^(a\.?m?\.?|p\.?m?\.?)/i,timezone:/^((e(s|d)t|c(s|d)t|m(s|d)t|p(s|d)t)|((gmt)?\s*(\+|\-)\s*\d\d\d\d?)|gmt)/i,ordinalSuffix:/^\s*(st|nd|rd|th)/i,timeContext:/^\s*(\:|a|p)/i},abbreviatedTimeZoneStandard:{GMT:"-000",EST:"-0400",CST:"-0500",MST:"-0600",PST:"-0700"},abbreviatedTimeZoneDST:{GMT:"-000",EDT:"-0500",CDT:"-0600",MDT:"-0700",PDT:"-0800"}};
+Date.getMonthNumberFromName=function(name){var n=Date.CultureInfo.monthNames,m=Date.CultureInfo.abbreviatedMonthNames,s=name.toLowerCase();for(var i=0;i<n.length;i++){if(n[i].toLowerCase()==s||m[i].toLowerCase()==s){return i;}}
+  return-1;};Date.getDayNumberFromName=function(name){var n=Date.CultureInfo.dayNames,m=Date.CultureInfo.abbreviatedDayNames,o=Date.CultureInfo.shortestDayNames,s=name.toLowerCase();for(var i=0;i<n.length;i++){if(n[i].toLowerCase()==s||m[i].toLowerCase()==s){return i;}}
+  return-1;};Date.isLeapYear=function(year){return(((year%4===0)&&(year%100!==0))||(year%400===0));};Date.getDaysInMonth=function(year,month){return[31,(Date.isLeapYear(year)?29:28),31,30,31,30,31,31,30,31,30,31][month];};Date.getTimezoneOffset=function(s,dst){return(dst||false)?Date.CultureInfo.abbreviatedTimeZoneDST[s.toUpperCase()]:Date.CultureInfo.abbreviatedTimeZoneStandard[s.toUpperCase()];};Date.getTimezoneAbbreviation=function(offset,dst){var n=(dst||false)?Date.CultureInfo.abbreviatedTimeZoneDST:Date.CultureInfo.abbreviatedTimeZoneStandard,p;for(p in n){if(n[p]===offset){return p;}}
+  return null;};Date.prototype.clone=function(){return new Date(this.getTime());};Date.prototype.compareTo=function(date){if(isNaN(this)){throw new Error(this);}
+  if(date instanceof Date&&!isNaN(date)){return(this>date)?1:(this<date)?-1:0;}else{throw new TypeError(date);}};Date.prototype.equals=function(date){return(this.compareTo(date)===0);};Date.prototype.between=function(start,end){var t=this.getTime();return t>=start.getTime()&&t<=end.getTime();};Date.prototype.addMilliseconds=function(value){this.setMilliseconds(this.getMilliseconds()+value);return this;};Date.prototype.addSeconds=function(value){return this.addMilliseconds(value*1000);};Date.prototype.addMinutes=function(value){return this.addMilliseconds(value*60000);};Date.prototype.addHours=function(value){return this.addMilliseconds(value*3600000);};Date.prototype.addDays=function(value){return this.addMilliseconds(value*86400000);};Date.prototype.addWeeks=function(value){return this.addMilliseconds(value*604800000);};Date.prototype.addMonths=function(value){var n=this.getDate();this.setDate(1);this.setMonth(this.getMonth()+value);this.setDate(Math.min(n,this.getDaysInMonth()));return this;};Date.prototype.addYears=function(value){return this.addMonths(value*12);};Date.prototype.add=function(config){if(typeof config=="number"){this._orient=config;return this;}
+  var x=config;if(x.millisecond||x.milliseconds){this.addMilliseconds(x.millisecond||x.milliseconds);}
+  if(x.second||x.seconds){this.addSeconds(x.second||x.seconds);}
+  if(x.minute||x.minutes){this.addMinutes(x.minute||x.minutes);}
+  if(x.hour||x.hours){this.addHours(x.hour||x.hours);}
+  if(x.month||x.months){this.addMonths(x.month||x.months);}
+  if(x.year||x.years){this.addYears(x.year||x.years);}
+  if(x.day||x.days){this.addDays(x.day||x.days);}
+  return this;};Date._validate=function(value,min,max,name){if(typeof value!="number"){throw new TypeError(value+" is not a Number.");}else if(value<min||value>max){throw new RangeError(value+" is not a valid value for "+name+".");}
+  return true;};Date.validateMillisecond=function(n){return Date._validate(n,0,999,"milliseconds");};Date.validateSecond=function(n){return Date._validate(n,0,59,"seconds");};Date.validateMinute=function(n){return Date._validate(n,0,59,"minutes");};Date.validateHour=function(n){return Date._validate(n,0,23,"hours");};Date.validateDay=function(n,year,month){return Date._validate(n,1,Date.getDaysInMonth(year,month),"days");};Date.validateMonth=function(n){return Date._validate(n,0,11,"months");};Date.validateYear=function(n){return Date._validate(n,1,9999,"seconds");};Date.prototype.set=function(config){var x=config;if(!x.millisecond&&x.millisecond!==0){x.millisecond=-1;}
+  if(!x.second&&x.second!==0){x.second=-1;}
+  if(!x.minute&&x.minute!==0){x.minute=-1;}
+  if(!x.hour&&x.hour!==0){x.hour=-1;}
+  if(!x.day&&x.day!==0){x.day=-1;}
+  if(!x.month&&x.month!==0){x.month=-1;}
+  if(!x.year&&x.year!==0){x.year=-1;}
+  if(x.millisecond!=-1&&Date.validateMillisecond(x.millisecond)){this.addMilliseconds(x.millisecond-this.getMilliseconds());}
+  if(x.second!=-1&&Date.validateSecond(x.second)){this.addSeconds(x.second-this.getSeconds());}
+  if(x.minute!=-1&&Date.validateMinute(x.minute)){this.addMinutes(x.minute-this.getMinutes());}
+  if(x.hour!=-1&&Date.validateHour(x.hour)){this.addHours(x.hour-this.getHours());}
+  if(x.month!==-1&&Date.validateMonth(x.month)){this.addMonths(x.month-this.getMonth());}
+  if(x.year!=-1&&Date.validateYear(x.year)){this.addYears(x.year-this.getFullYear());}
+  if(x.day!=-1&&Date.validateDay(x.day,this.getFullYear(),this.getMonth())){this.addDays(x.day-this.getDate());}
+  if(x.timezone){this.setTimezone(x.timezone);}
+  if(x.timezoneOffset){this.setTimezoneOffset(x.timezoneOffset);}
+  return this;};Date.prototype.clearTime=function(){this.setHours(0);this.setMinutes(0);this.setSeconds(0);this.setMilliseconds(0);return this;};Date.prototype.isLeapYear=function(){var y=this.getFullYear();return(((y%4===0)&&(y%100!==0))||(y%400===0));};Date.prototype.isWeekday=function(){return!(this.is().sat()||this.is().sun());};Date.prototype.getDaysInMonth=function(){return Date.getDaysInMonth(this.getFullYear(),this.getMonth());};Date.prototype.moveToFirstDayOfMonth=function(){return this.set({day:1});};Date.prototype.moveToLastDayOfMonth=function(){return this.set({day:this.getDaysInMonth()});};Date.prototype.moveToDayOfWeek=function(day,orient){var diff=(day-this.getDay()+7*(orient||+1))%7;return this.addDays((diff===0)?diff+=7*(orient||+1):diff);};Date.prototype.moveToMonth=function(month,orient){var diff=(month-this.getMonth()+12*(orient||+1))%12;return this.addMonths((diff===0)?diff+=12*(orient||+1):diff);};Date.prototype.getDayOfYear=function(){return Math.floor((this-new Date(this.getFullYear(),0,1))/86400000);};Date.prototype.getWeekOfYear=function(firstDayOfWeek){var y=this.getFullYear(),m=this.getMonth(),d=this.getDate();var dow=firstDayOfWeek||Date.CultureInfo.firstDayOfWeek;var offset=7+1-new Date(y,0,1).getDay();if(offset==8){offset=1;}
+  var daynum=((Date.UTC(y,m,d,0,0,0)-Date.UTC(y,0,1,0,0,0))/86400000)+1;var w=Math.floor((daynum-offset+7)/7);if(w===dow){y--;var prevOffset=7+1-new Date(y,0,1).getDay();if(prevOffset==2||prevOffset==8){w=53;}else{w=52;}}
+  return w;};Date.prototype.isDST=function(){console.log('isDST');return this.toString().match(/(E|C|M|P)(S|D)T/)[2]=="D";};Date.prototype.getTimezone=function(){return Date.getTimezoneAbbreviation(this.getUTCOffset,this.isDST());};Date.prototype.setTimezoneOffset=function(s){var here=this.getTimezoneOffset(),there=Number(s)*-6/10;this.addMinutes(there-here);return this;};Date.prototype.setTimezone=function(s){return this.setTimezoneOffset(Date.getTimezoneOffset(s));};Date.prototype.getUTCOffset=function(){var n=this.getTimezoneOffset()*-10/6,r;if(n<0){r=(n-10000).toString();return r[0]+r.substr(2);}else{r=(n+10000).toString();return"+"+r.substr(1);}};Date.prototype.getDayName=function(abbrev){return abbrev?Date.CultureInfo.abbreviatedDayNames[this.getDay()]:Date.CultureInfo.dayNames[this.getDay()];};Date.prototype.getMonthName=function(abbrev){return abbrev?Date.CultureInfo.abbreviatedMonthNames[this.getMonth()]:Date.CultureInfo.monthNames[this.getMonth()];};Date.prototype._toString=Date.prototype.toString;Date.prototype.toString=function(format){var self=this;var p=function p(s){return(s.toString().length==1)?"0"+s:s;};return format?format.replace(/dd?d?d?|MM?M?M?|yy?y?y?|hh?|HH?|mm?|ss?|tt?|zz?z?/g,function(format){switch(format){case"hh":return p(self.getHours()<13?self.getHours():(self.getHours()-12));case"h":return self.getHours()<13?self.getHours():(self.getHours()-12);case"HH":return p(self.getHours());case"H":return self.getHours();case"mm":return p(self.getMinutes());case"m":return self.getMinutes();case"ss":return p(self.getSeconds());case"s":return self.getSeconds();case"yyyy":return self.getFullYear();case"yy":return self.getFullYear().toString().substring(2,4);case"dddd":return self.getDayName();case"ddd":return self.getDayName(true);case"dd":return p(self.getDate());case"d":return self.getDate().toString();case"MMMM":return self.getMonthName();case"MMM":return self.getMonthName(true);case"MM":return p((self.getMonth()+1));case"M":return self.getMonth()+1;case"t":return self.getHours()<12?Date.CultureInfo.amDesignator.substring(0,1):Date.CultureInfo.pmDesignator.substring(0,1);case"tt":return self.getHours()<12?Date.CultureInfo.amDesignator:Date.CultureInfo.pmDesignator;case"zzz":case"zz":case"z":return"";}}):this._toString();};
+Date.now=function(){return new Date();};Date.today=function(){return Date.now().clearTime();};Date.prototype._orient=+1;Date.prototype.next=function(){this._orient=+1;return this;};Date.prototype.last=Date.prototype.prev=Date.prototype.previous=function(){this._orient=-1;return this;};Date.prototype._is=false;Date.prototype.is=function(){this._is=true;return this;};Number.prototype._dateElement="day";Number.prototype.fromNow=function(){var c={};c[this._dateElement]=this;return Date.now().add(c);};Number.prototype.ago=function(){var c={};c[this._dateElement]=this*-1;return Date.now().add(c);};(function(){var $D=Date.prototype,$N=Number.prototype;var dx=("sunday monday tuesday wednesday thursday friday saturday").split(/\s/),mx=("january february march april may june july august september october november december").split(/\s/),px=("Millisecond Second Minute Hour Day Week Month Year").split(/\s/),de;var df=function(n){return function(){if(this._is){this._is=false;return this.getDay()==n;}
+  return this.moveToDayOfWeek(n,this._orient);};};for(var i=0;i<dx.length;i++){$D[dx[i]]=$D[dx[i].substring(0,3)]=df(i);}
+  var mf=function(n){return function(){if(this._is){this._is=false;return this.getMonth()===n;}
+    return this.moveToMonth(n,this._orient);};};for(var j=0;j<mx.length;j++){$D[mx[j]]=$D[mx[j].substring(0,3)]=mf(j);}
+  var ef=function(j){return function(){if(j.substring(j.length-1)!="s"){j+="s";}
+    return this["add"+j](this._orient);};};var nf=function(n){return function(){this._dateElement=n;return this;};};for(var k=0;k<px.length;k++){de=px[k].toLowerCase();$D[de]=$D[de+"s"]=ef(px[k]);$N[de]=$N[de+"s"]=nf(de);}}());Date.prototype.toJSONString=function(){return this.toString("yyyy-MM-ddThh:mm:ssZ");};Date.prototype.toShortDateString=function(){return this.toString(Date.CultureInfo.formatPatterns.shortDatePattern);};Date.prototype.toLongDateString=function(){return this.toString(Date.CultureInfo.formatPatterns.longDatePattern);};Date.prototype.toShortTimeString=function(){return this.toString(Date.CultureInfo.formatPatterns.shortTimePattern);};Date.prototype.toLongTimeString=function(){return this.toString(Date.CultureInfo.formatPatterns.longTimePattern);};Date.prototype.getOrdinal=function(){switch(this.getDate()){case 1:case 21:case 31:return"st";case 2:case 22:return"nd";case 3:case 23:return"rd";default:return"th";}};
+(function(){Date.Parsing={Exception:function(s){this.message="Parse error at '"+s.substring(0,10)+" ...'";}};var $P=Date.Parsing;var _=$P.Operators={rtoken:function(r){return function(s){var mx=s.match(r);if(mx){return([mx[0],s.substring(mx[0].length)]);}else{throw new $P.Exception(s);}};},token:function(s){return function(s){return _.rtoken(new RegExp("^\s*"+s+"\s*"))(s);};},stoken:function(s){return _.rtoken(new RegExp("^"+s));},until:function(p){return function(s){var qx=[],rx=null;while(s.length){try{rx=p.call(this,s);}catch(e){qx.push(rx[0]);s=rx[1];continue;}
+  break;}
+  return[qx,s];};},many:function(p){return function(s){var rx=[],r=null;while(s.length){try{r=p.call(this,s);}catch(e){return[rx,s];}
+  rx.push(r[0]);s=r[1];}
+  return[rx,s];};},optional:function(p){return function(s){var r=null;try{r=p.call(this,s);}catch(e){return[null,s];}
+  return[r[0],r[1]];};},not:function(p){return function(s){try{p.call(this,s);}catch(e){return[null,s];}
+  throw new $P.Exception(s);};},ignore:function(p){return p?function(s){var r=null;r=p.call(this,s);return[null,r[1]];}:null;},product:function(){var px=arguments[0],qx=Array.prototype.slice.call(arguments,1),rx=[];for(var i=0;i<px.length;i++){rx.push(_.each(px[i],qx));}
+  return rx;},cache:function(rule){var cache={},r=null;return function(s){try{r=cache[s]=(cache[s]||rule.call(this,s));}catch(e){r=cache[s]=e;}
+  if(r instanceof $P.Exception){throw r;}else{return r;}};},any:function(){var px=arguments;return function(s){var r=null;for(var i=0;i<px.length;i++){if(px[i]==null){continue;}
+  try{r=(px[i].call(this,s));}catch(e){r=null;}
+  if(r){return r;}}
+  throw new $P.Exception(s);};},each:function(){var px=arguments;return function(s){var rx=[],r=null;for(var i=0;i<px.length;i++){if(px[i]==null){continue;}
+  try{r=(px[i].call(this,s));}catch(e){throw new $P.Exception(s);}
+  rx.push(r[0]);s=r[1];}
+  return[rx,s];};},all:function(){var px=arguments,_=_;return _.each(_.optional(px));},sequence:function(px,d,c){d=d||_.rtoken(/^\s*/);c=c||null;if(px.length==1){return px[0];}
+  return function(s){var r=null,q=null;var rx=[];for(var i=0;i<px.length;i++){try{r=px[i].call(this,s);}catch(e){break;}
+    rx.push(r[0]);try{q=d.call(this,r[1]);}catch(ex){q=null;break;}
+    s=q[1];}
+    if(!r){throw new $P.Exception(s);}
+    if(q){throw new $P.Exception(q[1]);}
+    if(c){try{r=c.call(this,r[1]);}catch(ey){throw new $P.Exception(r[1]);}}
+    return[rx,(r?r[1]:s)];};},between:function(d1,p,d2){d2=d2||d1;var _fn=_.each(_.ignore(d1),p,_.ignore(d2));return function(s){var rx=_fn.call(this,s);return[[rx[0][0],r[0][2]],rx[1]];};},list:function(p,d,c){d=d||_.rtoken(/^\s*/);c=c||null;return(p instanceof Array?_.each(_.product(p.slice(0,-1),_.ignore(d)),p.slice(-1),_.ignore(c)):_.each(_.many(_.each(p,_.ignore(d))),px,_.ignore(c)));},set:function(px,d,c){d=d||_.rtoken(/^\s*/);c=c||null;return function(s){var r=null,p=null,q=null,rx=null,best=[[],s],last=false;for(var i=0;i<px.length;i++){q=null;p=null;r=null;last=(px.length==1);try{r=px[i].call(this,s);}catch(e){continue;}
+  rx=[[r[0]],r[1]];if(r[1].length>0&&!last){try{q=d.call(this,r[1]);}catch(ex){last=true;}}else{last=true;}
+  if(!last&&q[1].length===0){last=true;}
+  if(!last){var qx=[];for(var j=0;j<px.length;j++){if(i!=j){qx.push(px[j]);}}
+    p=_.set(qx,d).call(this,q[1]);if(p[0].length>0){rx[0]=rx[0].concat(p[0]);rx[1]=p[1];}}
+  if(rx[1].length<best[1].length){best=rx;}
+  if(best[1].length===0){break;}}
+  if(best[0].length===0){return best;}
+  if(c){try{q=c.call(this,best[1]);}catch(ey){throw new $P.Exception(best[1]);}
+    best[1]=q[1];}
+  return best;};},forward:function(gr,fname){return function(s){return gr[fname].call(this,s);};},replace:function(rule,repl){return function(s){var r=rule.call(this,s);return[repl,r[1]];};},process:function(rule,fn){return function(s){var r=rule.call(this,s);return[fn.call(this,r[0]),r[1]];};},min:function(min,rule){return function(s){var rx=rule.call(this,s);if(rx[0].length<min){throw new $P.Exception(s);}
+  return rx;};}};var _generator=function(op){return function(){var args=null,rx=[];if(arguments.length>1){args=Array.prototype.slice.call(arguments);}else if(arguments[0]instanceof Array){args=arguments[0];}
+  if(args){for(var i=0,px=args.shift();i<px.length;i++){args.unshift(px[i]);rx.push(op.apply(null,args));args.shift();return rx;}}else{return op.apply(null,arguments);}};};var gx="optional not ignore cache".split(/\s/);for(var i=0;i<gx.length;i++){_[gx[i]]=_generator(_[gx[i]]);}
+  var _vector=function(op){return function(){if(arguments[0]instanceof Array){return op.apply(null,arguments[0]);}else{return op.apply(null,arguments);}};};var vx="each any all".split(/\s/);for(var j=0;j<vx.length;j++){_[vx[j]]=_vector(_[vx[j]]);}}());(function(){var flattenAndCompact=function(ax){var rx=[];for(var i=0;i<ax.length;i++){if(ax[i]instanceof Array){rx=rx.concat(flattenAndCompact(ax[i]));}else{if(ax[i]){rx.push(ax[i]);}}}
+  return rx;};Date.Grammar={};Date.Translator={hour:function(s){return function(){this.hour=Number(s);};},minute:function(s){return function(){this.minute=Number(s);};},second:function(s){return function(){this.second=Number(s);};},meridian:function(s){return function(){this.meridian=s.slice(0,1).toLowerCase();};},timezone:function(s){return function(){var n=s.replace(/[^\d\+\-]/g,"");if(n.length){this.timezoneOffset=Number(n);}else{this.timezone=s.toLowerCase();}};},day:function(x){var s=x[0];return function(){this.day=Number(s.match(/\d+/)[0]);};},month:function(s){return function(){this.month=((s.length==3)?Date.getMonthNumberFromName(s):(Number(s)-1));};},year:function(s){return function(){var n=Number(s);this.year=((s.length>2)?n:(n+(((n+2000)<Date.CultureInfo.twoDigitYearMax)?2000:1900)));};},rday:function(s){return function(){switch(s){case"yesterday":this.days=-1;break;case"tomorrow":this.days=1;break;case"today":this.days=0;break;case"now":this.days=0;this.now=true;break;}};},finishExact:function(x){x=(x instanceof Array)?x:[x];var now=new Date();this.year=now.getFullYear();this.month=now.getMonth();this.day=1;this.hour=0;this.minute=0;this.second=0;for(var i=0;i<x.length;i++){if(x[i]){x[i].call(this);}}
+  this.hour=(this.meridian=="p"&&this.hour<13)?this.hour+12:this.hour;if(this.day>Date.getDaysInMonth(this.year,this.month)){throw new RangeError(this.day+" is not a valid value for days.");}
+  var r=new Date(this.year,this.month,this.day,this.hour,this.minute,this.second);if(this.timezone){r.set({timezone:this.timezone});}else if(this.timezoneOffset){r.set({timezoneOffset:this.timezoneOffset});}
+  return r;},finish:function(x){x=(x instanceof Array)?flattenAndCompact(x):[x];if(x.length===0){return null;}
+  for(var i=0;i<x.length;i++){if(typeof x[i]=="function"){x[i].call(this);}}
+  if(this.now){return new Date();}
+  var today=Date.today();var method=null;var expression=!!(this.days!=null||this.orient||this.operator);if(expression){var gap,mod,orient;orient=((this.orient=="past"||this.operator=="subtract")?-1:1);if(this.weekday){this.unit="day";gap=(Date.getDayNumberFromName(this.weekday)-today.getDay());mod=7;this.days=gap?((gap+(orient*mod))%mod):(orient*mod);}
+    if(this.month){this.unit="month";gap=(this.month-today.getMonth());mod=12;this.months=gap?((gap+(orient*mod))%mod):(orient*mod);this.month=null;}
+    if(!this.unit){this.unit="day";}
+    if(this[this.unit+"s"]==null||this.operator!=null){if(!this.value){this.value=1;}
+      if(this.unit=="week"){this.unit="day";this.value=this.value*7;}
+      this[this.unit+"s"]=this.value*orient;}
+    return today.add(this);}else{if(this.meridian&&this.hour){this.hour=(this.hour<13&&this.meridian=="p")?this.hour+12:this.hour;}
+    if(this.weekday&&!this.day){this.day=(today.addDays((Date.getDayNumberFromName(this.weekday)-today.getDay()))).getDate();}
+    if(this.month&&!this.day){this.day=1;}
+    return today.set(this);}}};var _=Date.Parsing.Operators,g=Date.Grammar,t=Date.Translator,_fn;g.datePartDelimiter=_.rtoken(/^([\s\-\.\,\/\x27]+)/);g.timePartDelimiter=_.stoken(":");g.whiteSpace=_.rtoken(/^\s*/);g.generalDelimiter=_.rtoken(/^(([\s\,]|at|on)+)/);var _C={};g.ctoken=function(keys){var fn=_C[keys];if(!fn){var c=Date.CultureInfo.regexPatterns;var kx=keys.split(/\s+/),px=[];for(var i=0;i<kx.length;i++){px.push(_.replace(_.rtoken(c[kx[i]]),kx[i]));}
+  fn=_C[keys]=_.any.apply(null,px);}
+  return fn;};g.ctoken2=function(key){return _.rtoken(Date.CultureInfo.regexPatterns[key]);};g.h=_.cache(_.process(_.rtoken(/^(0[0-9]|1[0-2]|[1-9])/),t.hour));g.hh=_.cache(_.process(_.rtoken(/^(0[0-9]|1[0-2])/),t.hour));g.H=_.cache(_.process(_.rtoken(/^([0-1][0-9]|2[0-3]|[0-9])/),t.hour));g.HH=_.cache(_.process(_.rtoken(/^([0-1][0-9]|2[0-3])/),t.hour));g.m=_.cache(_.process(_.rtoken(/^([0-5][0-9]|[0-9])/),t.minute));g.mm=_.cache(_.process(_.rtoken(/^[0-5][0-9]/),t.minute));g.s=_.cache(_.process(_.rtoken(/^([0-5][0-9]|[0-9])/),t.second));g.ss=_.cache(_.process(_.rtoken(/^[0-5][0-9]/),t.second));g.hms=_.cache(_.sequence([g.H,g.mm,g.ss],g.timePartDelimiter));g.t=_.cache(_.process(g.ctoken2("shortMeridian"),t.meridian));g.tt=_.cache(_.process(g.ctoken2("longMeridian"),t.meridian));g.z=_.cache(_.process(_.rtoken(/^(\+|\-)?\s*\d\d\d\d?/),t.timezone));g.zz=_.cache(_.process(_.rtoken(/^(\+|\-)\s*\d\d\d\d/),t.timezone));g.zzz=_.cache(_.process(g.ctoken2("timezone"),t.timezone));g.timeSuffix=_.each(_.ignore(g.whiteSpace),_.set([g.tt,g.zzz]));g.time=_.each(_.optional(_.ignore(_.stoken("T"))),g.hms,g.timeSuffix);g.d=_.cache(_.process(_.each(_.rtoken(/^([0-2]\d|3[0-1]|\d)/),_.optional(g.ctoken2("ordinalSuffix"))),t.day));g.dd=_.cache(_.process(_.each(_.rtoken(/^([0-2]\d|3[0-1])/),_.optional(g.ctoken2("ordinalSuffix"))),t.day));g.ddd=g.dddd=_.cache(_.process(g.ctoken("sun mon tue wed thu fri sat"),function(s){return function(){this.weekday=s;};}));g.M=_.cache(_.process(_.rtoken(/^(1[0-2]|0\d|\d)/),t.month));g.MM=_.cache(_.process(_.rtoken(/^(1[0-2]|0\d)/),t.month));g.MMM=g.MMMM=_.cache(_.process(g.ctoken("jan feb mar apr may jun jul aug sep oct nov dec"),t.month));g.y=_.cache(_.process(_.rtoken(/^(\d\d?)/),t.year));g.yy=_.cache(_.process(_.rtoken(/^(\d\d)/),t.year));g.yyy=_.cache(_.process(_.rtoken(/^(\d\d?\d?\d?)/),t.year));g.yyyy=_.cache(_.process(_.rtoken(/^(\d\d\d\d)/),t.year));_fn=function(){return _.each(_.any.apply(null,arguments),_.not(g.ctoken2("timeContext")));};g.day=_fn(g.d,g.dd);g.month=_fn(g.M,g.MMM);g.year=_fn(g.yyyy,g.yy);g.orientation=_.process(g.ctoken("past future"),function(s){return function(){this.orient=s;};});g.operator=_.process(g.ctoken("add subtract"),function(s){return function(){this.operator=s;};});g.rday=_.process(g.ctoken("yesterday tomorrow today now"),t.rday);g.unit=_.process(g.ctoken("minute hour day week month year"),function(s){return function(){this.unit=s;};});g.value=_.process(_.rtoken(/^\d\d?(st|nd|rd|th)?/),function(s){return function(){this.value=s.replace(/\D/g,"");};});g.expression=_.set([g.rday,g.operator,g.value,g.unit,g.orientation,g.ddd,g.MMM]);_fn=function(){return _.set(arguments,g.datePartDelimiter);};g.mdy=_fn(g.ddd,g.month,g.day,g.year);g.ymd=_fn(g.ddd,g.year,g.month,g.day);g.dmy=_fn(g.ddd,g.day,g.month,g.year);g.date=function(s){return((g[Date.CultureInfo.dateElementOrder]||g.mdy).call(this,s));};g.format=_.process(_.many(_.any(_.process(_.rtoken(/^(dd?d?d?|MM?M?M?|yy?y?y?|hh?|HH?|mm?|ss?|tt?|zz?z?)/),function(fmt){if(g[fmt]){return g[fmt];}else{throw Date.Parsing.Exception(fmt);}}),_.process(_.rtoken(/^[^dMyhHmstz]+/),function(s){return _.ignore(_.stoken(s));}))),function(rules){return _.process(_.each.apply(null,rules),t.finishExact);});var _F={};var _get=function(f){return _F[f]=(_F[f]||g.format(f)[0]);};g.formats=function(fx){if(fx instanceof Array){var rx=[];for(var i=0;i<fx.length;i++){rx.push(_get(fx[i]));}
+  return _.any.apply(null,rx);}else{return _get(fx);}};g._formats=g.formats(["yyyy-MM-ddTHH:mm:ss","ddd, MMM dd, yyyy H:mm:ss tt","ddd MMM d yyyy HH:mm:ss zzz","d"]);g._start=_.process(_.set([g.date,g.time,g.expression],g.generalDelimiter,g.whiteSpace),t.finish);g.start=function(s){try{var r=g._formats.call({},s);if(r[1].length===0){return r;}}catch(e){}
+  return g._start.call({},s);};}());Date._parse=Date.parse;Date.parse=function(s){var r=null;if(!s){return null;}
+  try{r=Date.Grammar.start.call({},s);}catch(e){return null;}
+  return((r[1].length===0)?r[0]:null);};Date.getParseFunction=function(fx){var fn=Date.Grammar.formats(fx);return function(s){var r=null;try{r=fn.call({},s);}catch(e){return null;}
+  return((r[1].length===0)?r[0]:null);};};Date.parseExact=function(s,fx){return Date.getParseFunction(fx)(s);};

--- a/js/date.js
+++ b/js/date.js
@@ -1,223 +1,447 @@
 /**
- * Version: 1.0 Alpha-1 
+ * Version: 1.0 Alpha-1
  * Build Date: 13-Nov-2007
  * Copyright (c) 2006-2007, Coolite Inc. (http://www.coolite.com/). All rights reserved.
- * License: Licensed under The MIT License. See license.txt and http://www.datejs.com/license/. 
+ * License: Licensed under The MIT License. See license.txt and http://www.datejs.com/license/.
  * Website: http://www.datejs.com/ or http://www.coolite.com/datejs/
  */
-Date.CultureInfo = {name: 'en-US',englishName: 'English (United States)',nativeName: 'English (United States)',dayNames: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],abbreviatedDayNames: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],shortestDayNames: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],firstLetterDayNames: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],monthNames: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],abbreviatedMonthNames: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],amDesignator: 'AM',pmDesignator: 'PM',firstDayOfWeek: 0,twoDigitYearMax: 2029,dateElementOrder: 'mdy',formatPatterns: {shortDate: 'M/d/yyyy',longDate: 'dddd, MMMM dd, yyyy',shortTime: 'h:mm tt',longTime: 'h:mm:ss tt',fullDateTime: 'dddd, MMMM dd, yyyy h:mm:ss tt',sortableDateTime: 'yyyy-MM-ddTHH:mm:ss',universalSortableDateTime: 'yyyy-MM-dd HH:mm:ssZ',rfc1123: 'ddd, dd MMM yyyy HH:mm:ss GMT',monthDay: 'MMMM dd',yearMonth: 'MMMM, yyyy'},regexPatterns: {jan: /^jan(uary)?/i,feb: /^feb(ruary)?/i,mar: /^mar(ch)?/i,apr: /^apr(il)?/i,may: /^may/i,jun: /^jun(e)?/i,jul: /^jul(y)?/i,aug: /^aug(ust)?/i,sep: /^sep(t(ember)?)?/i,oct: /^oct(ober)?/i,nov: /^nov(ember)?/i,dec: /^dec(ember)?/i,sun: /^su(n(day)?)?/i,mon: /^mo(n(day)?)?/i,tue: /^tu(e(s(day)?)?)?/i,wed: /^we(d(nesday)?)?/i,thu: /^th(u(r(s(day)?)?)?)?/i,fri: /^fr(i(day)?)?/i,sat: /^sa(t(urday)?)?/i,future: /^next/i,past: /^last|past|prev(ious)?/i,add: /^(\+|after|from)/i,subtract: /^(\-|before|ago)/i,yesterday: /^yesterday/i,today: /^t(oday)?/i,tomorrow: /^tomorrow/i,now: /^n(ow)?/i,millisecond: /^ms|milli(second)?s?/i,second: /^sec(ond)?s?/i,minute: /^min(ute)?s?/i,hour: /^h(ou)?rs?/i,week: /^w(ee)?k/i,month: /^m(o(nth)?s?)?/i,day: /^d(ays?)?/i,year: /^y((ea)?rs?)?/i,shortMeridian: /^(a|p)/i,longMeridian: /^(a\.?m?\.?|p\.?m?\.?)/i,timezone: /^((e(s|d)t|c(s|d)t|m(s|d)t|p(s|d)t)|((gmt)?\s*(\+|\-)\s*\d\d\d\d?)|gmt)/i,ordinalSuffix: /^\s*(st|nd|rd|th)/i,timeContext: /^\s*(\:|a|p)/i},abbreviatedTimeZoneStandard: {GMT: '-000',EST: '-0400',CST: '-0500',MST: '-0600',PST: '-0700'},abbreviatedTimeZoneDST: {GMT: '-000',EDT: '-0500',CDT: '-0600',MDT: '-0700',PDT: '-0800'}}
-Date.getMonthNumberFromName = function (name) {var n = Date.CultureInfo.monthNames,m = Date.CultureInfo.abbreviatedMonthNames,s = name.toLowerCase()
-  for (var i = 0;i < n.length;i++) {if (n[i].toLowerCase() == s || m[i].toLowerCase() == s) {return i;}}
-  return -1;};Date.getDayNumberFromName = function (name) {var n = Date.CultureInfo.dayNames,m = Date.CultureInfo.abbreviatedDayNames,o = Date.CultureInfo.shortestDayNames,s = name.toLowerCase()
-  for (var i = 0;i < n.length;i++) {if (n[i].toLowerCase() == s || m[i].toLowerCase() == s) {return i;}}
-  return -1;};Date.isLeapYear = function (year) {return (((year % 4 === 0) && (year % 100 !== 0)) || (year % 400 === 0));};Date.getDaysInMonth = function (year, month) {return [31,(Date.isLeapYear(year) ? 29 : 28), 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month];};Date.getTimezoneOffset = function (s, dst) {return (dst || false) ? Date.CultureInfo.abbreviatedTimeZoneDST[s.toUpperCase()] : Date.CultureInfo.abbreviatedTimeZoneStandard[s.toUpperCase()];};Date.getTimezoneAbbreviation = function (offset, dst) {var n = (dst || false) ? Date.CultureInfo.abbreviatedTimeZoneDST : Date.CultureInfo.abbreviatedTimeZoneStandard,p
-  for (p in n) {if (n[p] === offset) {return p;} }
-  return null;};Date.prototype.clone = function () {return new Date(this.getTime());};Date.prototype.compareTo = function (date) {if (isNaN(this)) {throw new Error(this);}
-  if (date instanceof Date && !isNaN(date)) {return (this > date) ? 1 : (this < date) ? -1 : 0;}else {throw new TypeError(date);}};Date.prototype.equals = function (date) {return (this.compareTo(date) === 0);};Date.prototype.between = function (start, end) {var t = this.getTime()
-  return t >= start.getTime() && t <= end.getTime();};Date.prototype.addMilliseconds = function (value) {this.setMilliseconds(this.getMilliseconds() + value);return this;};Date.prototype.addSeconds = function (value) {return this.addMilliseconds(value * 1000);};Date.prototype.addMinutes = function (value) {return this.addMilliseconds(value * 60000);};Date.prototype.addHours = function (value) {return this.addMilliseconds(value * 3600000);};Date.prototype.addDays = function (value) {return this.addMilliseconds(value * 86400000);};Date.prototype.addWeeks = function (value) {return this.addMilliseconds(value * 604800000);};Date.prototype.addMonths = function (value) {var n = this.getDate()
-  this.setDate(1);this.setMonth(this.getMonth() + value);this.setDate(Math.min(n, this.getDaysInMonth()));return this;};Date.prototype.addYears = function (value) {return this.addMonths(value * 12);};Date.prototype.add = function (config) {if (typeof config == 'number') {this._orient = config;return this;}
+Date.CultureInfo = {name: 'en-US', englishName: 'English (United States)', nativeName: 'English (United States)', dayNames: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'], abbreviatedDayNames: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'], shortestDayNames: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'], firstLetterDayNames: ['S', 'M', 'T', 'W', 'T', 'F', 'S'], monthNames: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'], abbreviatedMonthNames: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'], amDesignator: 'AM', pmDesignator: 'PM', firstDayOfWeek: 0, twoDigitYearMax: 2029, dateElementOrder: 'mdy', formatPatterns: {shortDate: 'M/d/yyyy', longDate: 'dddd, MMMM dd, yyyy', shortTime: 'h:mm tt', longTime: 'h:mm:ss tt', fullDateTime: 'dddd, MMMM dd, yyyy h:mm:ss tt', sortableDateTime: 'yyyy-MM-ddTHH:mm:ss', universalSortableDateTime: 'yyyy-MM-dd HH:mm:ssZ', rfc1123: 'ddd, dd MMM yyyy HH:mm:ss GMT', monthDay: 'MMMM dd', yearMonth: 'MMMM, yyyy'}, regexPatterns: {jan: /^jan(uary)?/i, feb: /^feb(ruary)?/i, mar: /^mar(ch)?/i, apr: /^apr(il)?/i, may: /^may/i, jun: /^jun(e)?/i, jul: /^jul(y)?/i, aug: /^aug(ust)?/i, sep: /^sep(t(ember)?)?/i, oct: /^oct(ober)?/i, nov: /^nov(ember)?/i, dec: /^dec(ember)?/i, sun: /^su(n(day)?)?/i, mon: /^mo(n(day)?)?/i, tue: /^tu(e(s(day)?)?)?/i, wed: /^we(d(nesday)?)?/i, thu: /^th(u(r(s(day)?)?)?)?/i, fri: /^fr(i(day)?)?/i, sat: /^sa(t(urday)?)?/i, future: /^next/i, past: /^last|past|prev(ious)?/i, add: /^(\+|after|from)/i, subtract: /^(\-|before|ago)/i, yesterday: /^yesterday/i, today: /^t(oday)?/i, tomorrow: /^tomorrow/i, now: /^n(ow)?/i, millisecond: /^ms|milli(second)?s?/i, second: /^sec(ond)?s?/i, minute: /^min(ute)?s?/i, hour: /^h(ou)?rs?/i, week: /^w(ee)?k/i, month: /^m(o(nth)?s?)?/i, day: /^d(ays?)?/i, year: /^y((ea)?rs?)?/i, shortMeridian: /^(a|p)/i, longMeridian: /^(a\.?m?\.?|p\.?m?\.?)/i, timezone: /^((e(s|d)t|c(s|d)t|m(s|d)t|p(s|d)t)|((gmt)?\s*(\+|\-)\s*\d\d\d\d?)|gmt)/i, ordinalSuffix: /^\s*(st|nd|rd|th)/i, timeContext: /^\s*(\:|a|p)/i}, abbreviatedTimeZoneStandard: {GMT: '-000', EST: '-0400', CST: '-0500', MST: '-0600', PST: '-0700'}, abbreviatedTimeZoneDST: {GMT: '-000', EDT: '-0500', CDT: '-0600', MDT: '-0700', PDT: '-0800'}}
+Date.getMonthNumberFromName = function (name) {
+  var n = Date.CultureInfo.monthNames, m = Date.CultureInfo.abbreviatedMonthNames, s = name.toLowerCase()
+  for (var i = 0; i < n.length; i++) { if (n[i].toLowerCase() == s || m[i].toLowerCase() == s) { return i } }
+  return -1
+}; Date.getDayNumberFromName = function (name) {
+  var n = Date.CultureInfo.dayNames, m = Date.CultureInfo.abbreviatedDayNames, o = Date.CultureInfo.shortestDayNames, s = name.toLowerCase()
+  for (var i = 0; i < n.length; i++) { if (n[i].toLowerCase() == s || m[i].toLowerCase() == s) { return i } }
+  return -1
+}; Date.isLeapYear = function (year) { return (((year % 4 === 0) && (year % 100 !== 0)) || (year % 400 === 0)) }; Date.getDaysInMonth = function (year, month) { return [31, (Date.isLeapYear(year) ? 29 : 28), 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month] }; Date.getTimezoneOffset = function (s, dst) { return (dst || false) ? Date.CultureInfo.abbreviatedTimeZoneDST[s.toUpperCase()] : Date.CultureInfo.abbreviatedTimeZoneStandard[s.toUpperCase()] }; Date.getTimezoneAbbreviation = function (offset, dst) {
+  var n = (dst || false) ? Date.CultureInfo.abbreviatedTimeZoneDST : Date.CultureInfo.abbreviatedTimeZoneStandard, p
+  for (p in n) { if (n[p] === offset) { return p } }
+  return null
+}; Date.prototype.clone = function () { return new Date(this.getTime()) }; Date.prototype.compareTo = function (date) {
+  if (isNaN(this)) { throw new Error(this) }
+  if (date instanceof Date && !isNaN(date)) { return (this > date) ? 1 : (this < date) ? -1 : 0 } else { throw new TypeError(date) }
+}; Date.prototype.equals = function (date) { return (this.compareTo(date) === 0) }; Date.prototype.between = function (start, end) {
+  var t = this.getTime()
+  return t >= start.getTime() && t <= end.getTime()
+}; Date.prototype.addMilliseconds = function (value) { this.setMilliseconds(this.getMilliseconds() + value); return this }; Date.prototype.addSeconds = function (value) { return this.addMilliseconds(value * 1000) }; Date.prototype.addMinutes = function (value) { return this.addMilliseconds(value * 60000) }; Date.prototype.addHours = function (value) { return this.addMilliseconds(value * 3600000) }; Date.prototype.addDays = function (value) { return this.addMilliseconds(value * 86400000) }; Date.prototype.addWeeks = function (value) { return this.addMilliseconds(value * 604800000) }; Date.prototype.addMonths = function (value) {
+  var n = this.getDate()
+  this.setDate(1); this.setMonth(this.getMonth() + value); this.setDate(Math.min(n, this.getDaysInMonth())); return this
+}; Date.prototype.addYears = function (value) { return this.addMonths(value * 12) }; Date.prototype.add = function (config) {
+  if (typeof config === 'number') { this._orient = config; return this }
   var x = config
-  if (x.millisecond || x.milliseconds) {this.addMilliseconds(x.millisecond || x.milliseconds);}
-  if (x.second || x.seconds) {this.addSeconds(x.second || x.seconds);}
-  if (x.minute || x.minutes) {this.addMinutes(x.minute || x.minutes);}
-  if (x.hour || x.hours) {this.addHours(x.hour || x.hours);}
-  if (x.month || x.months) {this.addMonths(x.month || x.months);}
-  if (x.year || x.years) {this.addYears(x.year || x.years);}
-  if (x.day || x.days) {this.addDays(x.day || x.days);}
-  return this;};Date._validate = function (value, min, max, name) {if (typeof value != 'number') {throw new TypeError(value + ' is not a Number.');}else if (value < min || value > max) {throw new RangeError(value + ' is not a valid value for ' + name + '.');}
-  return true;};Date.validateMillisecond = function (n) {return Date._validate(n, 0, 999, 'milliseconds');};Date.validateSecond = function (n) {return Date._validate(n, 0, 59, 'seconds');};Date.validateMinute = function (n) {return Date._validate(n, 0, 59, 'minutes');};Date.validateHour = function (n) {return Date._validate(n, 0, 23, 'hours');};Date.validateDay = function (n, year, month) {return Date._validate(n, 1, Date.getDaysInMonth(year, month), 'days');};Date.validateMonth = function (n) {return Date._validate(n, 0, 11, 'months');};Date.validateYear = function (n) {return Date._validate(n, 1, 9999, 'seconds');};Date.prototype.set = function (config) {var x = config
-  if (!x.millisecond && x.millisecond !== 0) {x.millisecond = -1;}
-  if (!x.second && x.second !== 0) {x.second = -1;}
-  if (!x.minute && x.minute !== 0) {x.minute = -1;}
-  if (!x.hour && x.hour !== 0) {x.hour = -1;}
-  if (!x.day && x.day !== 0) {x.day = -1;}
-  if (!x.month && x.month !== 0) {x.month = -1;}
-  if (!x.year && x.year !== 0) {x.year = -1;}
-  if (x.millisecond != -1 && Date.validateMillisecond(x.millisecond)) {this.addMilliseconds(x.millisecond - this.getMilliseconds());}
-  if (x.second != -1 && Date.validateSecond(x.second)) {this.addSeconds(x.second - this.getSeconds());}
-  if (x.minute != -1 && Date.validateMinute(x.minute)) {this.addMinutes(x.minute - this.getMinutes());}
-  if (x.hour != -1 && Date.validateHour(x.hour)) {this.addHours(x.hour - this.getHours());}
-  if (x.month !== -1 && Date.validateMonth(x.month)) {this.addMonths(x.month - this.getMonth());}
-  if (x.year != -1 && Date.validateYear(x.year)) {this.addYears(x.year - this.getFullYear());}
-  if (x.day != -1 && Date.validateDay(x.day, this.getFullYear(), this.getMonth())) {this.addDays(x.day - this.getDate());}
-  if (x.timezone) {this.setTimezone(x.timezone);}
-  if (x.timezoneOffset) {this.setTimezoneOffset(x.timezoneOffset);}
-  return this;};Date.prototype.clearTime = function () {this.setHours(0);this.setMinutes(0);this.setSeconds(0);this.setMilliseconds(0);return this;};Date.prototype.isLeapYear = function () {var y = this.getFullYear()
-  return (((y % 4 === 0) && (y % 100 !== 0)) || (y % 400 === 0));};Date.prototype.isWeekday = function () {return !(this.is().sat() || this.is().sun());};Date.prototype.getDaysInMonth = function () {return Date.getDaysInMonth(this.getFullYear(), this.getMonth());};Date.prototype.moveToFirstDayOfMonth = function () {return this.set({day: 1});};Date.prototype.moveToLastDayOfMonth = function () {return this.set({day: this.getDaysInMonth()});};Date.prototype.moveToDayOfWeek = function (day, orient) {var diff = (day - this.getDay() + 7 * (orient || +1)) % 7
-  return this.addDays((diff === 0) ? diff += 7 * (orient || +1) : diff);};Date.prototype.moveToMonth = function (month, orient) {var diff = (month - this.getMonth() + 12 * (orient || +1)) % 12
-  return this.addMonths((diff === 0) ? diff += 12 * (orient || +1) : diff);};Date.prototype.getDayOfYear = function () {return Math.floor((this - new Date(this.getFullYear(), 0, 1)) / 86400000);};Date.prototype.getWeekOfYear = function (firstDayOfWeek) {var y = this.getFullYear(),m = this.getMonth(),d = this.getDate()
+  if (x.millisecond || x.milliseconds) { this.addMilliseconds(x.millisecond || x.milliseconds) }
+  if (x.second || x.seconds) { this.addSeconds(x.second || x.seconds) }
+  if (x.minute || x.minutes) { this.addMinutes(x.minute || x.minutes) }
+  if (x.hour || x.hours) { this.addHours(x.hour || x.hours) }
+  if (x.month || x.months) { this.addMonths(x.month || x.months) }
+  if (x.year || x.years) { this.addYears(x.year || x.years) }
+  if (x.day || x.days) { this.addDays(x.day || x.days) }
+  return this
+}; Date._validate = function (value, min, max, name) {
+  if (typeof value !== 'number') { throw new TypeError(value + ' is not a Number.') } else if (value < min || value > max) { throw new RangeError(value + ' is not a valid value for ' + name + '.') }
+  return true
+}; Date.validateMillisecond = function (n) { return Date._validate(n, 0, 999, 'milliseconds') }; Date.validateSecond = function (n) { return Date._validate(n, 0, 59, 'seconds') }; Date.validateMinute = function (n) { return Date._validate(n, 0, 59, 'minutes') }; Date.validateHour = function (n) { return Date._validate(n, 0, 23, 'hours') }; Date.validateDay = function (n, year, month) { return Date._validate(n, 1, Date.getDaysInMonth(year, month), 'days') }; Date.validateMonth = function (n) { return Date._validate(n, 0, 11, 'months') }; Date.validateYear = function (n) { return Date._validate(n, 1, 9999, 'seconds') }; Date.prototype.set = function (config) {
+  var x = config
+  if (!x.millisecond && x.millisecond !== 0) { x.millisecond = -1 }
+  if (!x.second && x.second !== 0) { x.second = -1 }
+  if (!x.minute && x.minute !== 0) { x.minute = -1 }
+  if (!x.hour && x.hour !== 0) { x.hour = -1 }
+  if (!x.day && x.day !== 0) { x.day = -1 }
+  if (!x.month && x.month !== 0) { x.month = -1 }
+  if (!x.year && x.year !== 0) { x.year = -1 }
+  if (x.millisecond != -1 && Date.validateMillisecond(x.millisecond)) { this.addMilliseconds(x.millisecond - this.getMilliseconds()) }
+  if (x.second != -1 && Date.validateSecond(x.second)) { this.addSeconds(x.second - this.getSeconds()) }
+  if (x.minute != -1 && Date.validateMinute(x.minute)) { this.addMinutes(x.minute - this.getMinutes()) }
+  if (x.hour != -1 && Date.validateHour(x.hour)) { this.addHours(x.hour - this.getHours()) }
+  if (x.month !== -1 && Date.validateMonth(x.month)) { this.addMonths(x.month - this.getMonth()) }
+  if (x.year != -1 && Date.validateYear(x.year)) { this.addYears(x.year - this.getFullYear()) }
+  if (x.day != -1 && Date.validateDay(x.day, this.getFullYear(), this.getMonth())) { this.addDays(x.day - this.getDate()) }
+  if (x.timezone) { this.setTimezone(x.timezone) }
+  if (x.timezoneOffset) { this.setTimezoneOffset(x.timezoneOffset) }
+  return this
+}; Date.prototype.clearTime = function () { this.setHours(0); this.setMinutes(0); this.setSeconds(0); this.setMilliseconds(0); return this }; Date.prototype.isLeapYear = function () {
+  var y = this.getFullYear()
+  return (((y % 4 === 0) && (y % 100 !== 0)) || (y % 400 === 0))
+}; Date.prototype.isWeekday = function () { return !(this.is().sat() || this.is().sun()) }; Date.prototype.getDaysInMonth = function () { return Date.getDaysInMonth(this.getFullYear(), this.getMonth()) }; Date.prototype.moveToFirstDayOfMonth = function () { return this.set({day: 1}) }; Date.prototype.moveToLastDayOfMonth = function () { return this.set({day: this.getDaysInMonth()}) }; Date.prototype.moveToDayOfWeek = function (day, orient) {
+  var diff = (day - this.getDay() + 7 * (orient || +1)) % 7
+  return this.addDays((diff === 0) ? diff += 7 * (orient || +1) : diff)
+}; Date.prototype.moveToMonth = function (month, orient) {
+  var diff = (month - this.getMonth() + 12 * (orient || +1)) % 12
+  return this.addMonths((diff === 0) ? diff += 12 * (orient || +1) : diff)
+}; Date.prototype.getDayOfYear = function () { return Math.floor((this - new Date(this.getFullYear(), 0, 1)) / 86400000) }; Date.prototype.getWeekOfYear = function (firstDayOfWeek) {
+  var y = this.getFullYear(), m = this.getMonth(), d = this.getDate()
   var dow = firstDayOfWeek || Date.CultureInfo.firstDayOfWeek
   var offset = 7 + 1 - new Date(y, 0, 1).getDay()
-  if (offset == 8) {offset = 1;}
+  if (offset == 8) { offset = 1 }
   var daynum = ((Date.UTC(y, m, d, 0, 0, 0) - Date.UTC(y, 0, 1, 0, 0, 0)) / 86400000) + 1
   var w = Math.floor((daynum - offset + 7) / 7)
-  if (w === dow) {y--;var prevOffset = 7 + 1 - new Date(y, 0, 1).getDay()
-    if (prevOffset == 2 || prevOffset == 8) {w = 53;}else {w = 52;}}
-  return w;};Date.prototype.isDST = function () {console.log('isDST');return this.toString().match(/(E|C|M|P)(S|D)T/)[2] == 'D';};Date.prototype.getTimezone = function () {return Date.getTimezoneAbbreviation(this.getUTCOffset, this.isDST());};Date.prototype.setTimezoneOffset = function (s) {var here = this.getTimezoneOffset(),there = Number(s) * -6 / 10
-  this.addMinutes(there - here);return this;};Date.prototype.setTimezone = function (s) {return this.setTimezoneOffset(Date.getTimezoneOffset(s));};Date.prototype.getUTCOffset = function () {var n = this.getTimezoneOffset() * -10 / 6,r
-  if (n < 0) {r = (n - 10000).toString();return r[0] + r.substr(2);}else {r = (n + 10000).toString();return '+' + r.substr(1);}};Date.prototype.getDayName = function (abbrev) {return abbrev ? Date.CultureInfo.abbreviatedDayNames[this.getDay()] : Date.CultureInfo.dayNames[this.getDay()];};Date.prototype.getMonthName = function (abbrev) {return abbrev ? Date.CultureInfo.abbreviatedMonthNames[this.getMonth()] : Date.CultureInfo.monthNames[this.getMonth()];};Date.prototype._toString = Date.prototype.toString;Date.prototype.toString = function (format) {var self = this
-  var p = function p (s) {return (s.toString().length == 1) ? '0' + s : s;}
-  return format ? format.replace(/dd?d?d?|MM?M?M?|yy?y?y?|hh?|HH?|mm?|ss?|tt?|zz?z?/g, function (format) {switch (format) {case 'hh':
-        return p(self.getHours() < 13 ? self.getHours() : (self.getHours() - 12));case 'h':
-        return self.getHours() < 13 ? self.getHours() : (self.getHours() - 12);case 'HH':
-        return p(self.getHours());case 'H':
-        return self.getHours();case 'mm':
-        return p(self.getMinutes());case 'm':
-        return self.getMinutes();case 'ss':
-        return p(self.getSeconds());case 's':
-        return self.getSeconds();case 'yyyy':
-        return self.getFullYear();case 'yy':
-        return self.getFullYear().toString().substring(2, 4);case 'dddd':
-        return self.getDayName();case 'ddd':
-        return self.getDayName(true);case 'dd':
-        return p(self.getDate());case 'd':
-        return self.getDate().toString();case 'MMMM':
-        return self.getMonthName();case 'MMM':
-        return self.getMonthName(true);case 'MM':
-        return p((self.getMonth() + 1));case 'M':
-        return self.getMonth() + 1;case 't':
-        return self.getHours() < 12 ? Date.CultureInfo.amDesignator.substring(0, 1) : Date.CultureInfo.pmDesignator.substring(0, 1);case 'tt':
-        return self.getHours() < 12 ? Date.CultureInfo.amDesignator : Date.CultureInfo.pmDesignator;case 'zzz':
+  if (w === dow) {
+    y--; var prevOffset = 7 + 1 - new Date(y, 0, 1).getDay()
+    if (prevOffset == 2 || prevOffset == 8) { w = 53 } else { w = 52 }
+  }
+  return w
+}; Date.prototype.isDST = function () { console.log('isDST'); return this.toString().match(/(E|C|M|P)(S|D)T/)[2] == 'D' }; Date.prototype.getTimezone = function () { return Date.getTimezoneAbbreviation(this.getUTCOffset, this.isDST()) }; Date.prototype.setTimezoneOffset = function (s) {
+  var here = this.getTimezoneOffset(), there = Number(s) * -6 / 10
+  this.addMinutes(there - here); return this
+}; Date.prototype.setTimezone = function (s) { return this.setTimezoneOffset(Date.getTimezoneOffset(s)) }; Date.prototype.getUTCOffset = function () {
+  var n = this.getTimezoneOffset() * -10 / 6, r
+  if (n < 0) { r = (n - 10000).toString(); return r[0] + r.substr(2) } else { r = (n + 10000).toString(); return '+' + r.substr(1) }
+}; Date.prototype.getDayName = function (abbrev) { return abbrev ? Date.CultureInfo.abbreviatedDayNames[this.getDay()] : Date.CultureInfo.dayNames[this.getDay()] }; Date.prototype.getMonthName = function (abbrev) { return abbrev ? Date.CultureInfo.abbreviatedMonthNames[this.getMonth()] : Date.CultureInfo.monthNames[this.getMonth()] }; Date.prototype._toString = Date.prototype.toString; Date.prototype.toString = function (format) {
+  var self = this
+  var p = function p (s) { return (s.toString().length == 1) ? '0' + s : s }
+  return format ? format.replace(/dd?d?d?|MM?M?M?|yy?y?y?|hh?|HH?|mm?|ss?|tt?|zz?z?/g, function (format) {
+    switch (format) {
+      case 'hh':
+        return p(self.getHours() < 13 ? self.getHours() : (self.getHours() - 12)); case 'h':
+        return self.getHours() < 13 ? self.getHours() : (self.getHours() - 12); case 'HH':
+        return p(self.getHours()); case 'H':
+        return self.getHours(); case 'mm':
+        return p(self.getMinutes()); case 'm':
+        return self.getMinutes(); case 'ss':
+        return p(self.getSeconds()); case 's':
+        return self.getSeconds(); case 'yyyy':
+        return self.getFullYear(); case 'yy':
+        return self.getFullYear().toString().substring(2, 4); case 'dddd':
+        return self.getDayName(); case 'ddd':
+        return self.getDayName(true); case 'dd':
+        return p(self.getDate()); case 'd':
+        return self.getDate().toString(); case 'MMMM':
+        return self.getMonthName(); case 'MMM':
+        return self.getMonthName(true); case 'MM':
+        return p((self.getMonth() + 1)); case 'M':
+        return self.getMonth() + 1; case 't':
+        return self.getHours() < 12 ? Date.CultureInfo.amDesignator.substring(0, 1) : Date.CultureInfo.pmDesignator.substring(0, 1); case 'tt':
+        return self.getHours() < 12 ? Date.CultureInfo.amDesignator : Date.CultureInfo.pmDesignator; case 'zzz':
       case 'zz':
       case 'z':
-        return '';}}) : this._toString();}
-Date.now = function () {return new Date();};Date.today = function () {return Date.now().clearTime();};Date.prototype._orient = +1;Date.prototype.next = function () {this._orient = +1;return this;};Date.prototype.last = Date.prototype.prev = Date.prototype.previous = function () {this._orient = -1;return this;};Date.prototype._is = false;Date.prototype.is = function () {this._is = true;return this;};Number.prototype._dateElement = 'day';Number.prototype.fromNow = function () {var c = {}
-  c[this._dateElement] = this;return Date.now().add(c);};Number.prototype.ago = function () {var c = {}
-  c[this._dateElement] = this * -1;return Date.now().add(c);}
-;(function () {var $D = Date.prototype,$N = Number.prototype
-  var dx = ('sunday monday tuesday wednesday thursday friday saturday').split(/\s/),mx = ('january february march april may june july august september october november december').split(/\s/),px = ('Millisecond Second Minute Hour Day Week Month Year').split(/\s/),de
-  var df = function (n) {return function () {if (this._is) {this._is = false;return this.getDay() == n;}
-      return this.moveToDayOfWeek(n, this._orient);};}
-  for (var i = 0;i < dx.length;i++) {$D[dx[i]] = $D[dx[i].substring(0, 3)] = df(i);}
-  var mf = function (n) {return function () {if (this._is) {this._is = false;return this.getMonth() === n;}
-      return this.moveToMonth(n, this._orient);};}
-  for (var j = 0;j < mx.length;j++) {$D[mx[j]] = $D[mx[j].substring(0, 3)] = mf(j);}
-  var ef = function (j) {return function () {if (j.substring(j.length - 1) != 's') {j += 's';}
-      return this['add' + j](this._orient);};}
-  var nf = function (n) {return function () {this._dateElement = n;return this;};}
-  for (var k = 0;k < px.length;k++) {de = px[k].toLowerCase();$D[de] = $D[de + 's'] = ef(px[k]);$N[de] = $N[de + 's'] = nf(de);}}());Date.prototype.toJSONString = function () {return this.toString('yyyy-MM-ddThh:mm:ssZ');};Date.prototype.toShortDateString = function () {return this.toString(Date.CultureInfo.formatPatterns.shortDatePattern);};Date.prototype.toLongDateString = function () {return this.toString(Date.CultureInfo.formatPatterns.longDatePattern);};Date.prototype.toShortTimeString = function () {return this.toString(Date.CultureInfo.formatPatterns.shortTimePattern);};Date.prototype.toLongTimeString = function () {return this.toString(Date.CultureInfo.formatPatterns.longTimePattern);};Date.prototype.getOrdinal = function () {switch (this.getDate()) {case 1:
+        return ''
+    }
+  }) : this._toString()
+}
+Date.now = function () { return new Date() }; Date.today = function () { return Date.now().clearTime() }; Date.prototype._orient = +1; Date.prototype.next = function () { this._orient = +1; return this }; Date.prototype.last = Date.prototype.prev = Date.prototype.previous = function () { this._orient = -1; return this }; Date.prototype._is = false; Date.prototype.is = function () { this._is = true; return this }; Number.prototype._dateElement = 'day'; Number.prototype.fromNow = function () {
+  var c = {}
+  c[this._dateElement] = this; return Date.now().add(c)
+}; Number.prototype.ago = function () {
+  var c = {}
+  c[this._dateElement] = this * -1; return Date.now().add(c)
+}
+;(function () {
+  var $D = Date.prototype, $N = Number.prototype
+  var dx = ('sunday monday tuesday wednesday thursday friday saturday').split(/\s/), mx = ('january february march april may june july august september october november december').split(/\s/), px = ('Millisecond Second Minute Hour Day Week Month Year').split(/\s/), de
+  var df = function (n) {
+    return function () {
+      if (this._is) { this._is = false; return this.getDay() == n }
+      return this.moveToDayOfWeek(n, this._orient)
+    }
+  }
+  for (var i = 0; i < dx.length; i++) { $D[dx[i]] = $D[dx[i].substring(0, 3)] = df(i) }
+  var mf = function (n) {
+    return function () {
+      if (this._is) { this._is = false; return this.getMonth() === n }
+      return this.moveToMonth(n, this._orient)
+    }
+  }
+  for (var j = 0; j < mx.length; j++) { $D[mx[j]] = $D[mx[j].substring(0, 3)] = mf(j) }
+  var ef = function (j) {
+    return function () {
+      if (j.substring(j.length - 1) != 's') { j += 's' }
+      return this['add' + j](this._orient)
+    }
+  }
+  var nf = function (n) { return function () { this._dateElement = n; return this } }
+  for (var k = 0; k < px.length; k++) { de = px[k].toLowerCase(); $D[de] = $D[de + 's'] = ef(px[k]); $N[de] = $N[de + 's'] = nf(de) }
+}()); Date.prototype.toJSONString = function () { return this.toString('yyyy-MM-ddThh:mm:ssZ') }; Date.prototype.toShortDateString = function () { return this.toString(Date.CultureInfo.formatPatterns.shortDatePattern) }; Date.prototype.toLongDateString = function () { return this.toString(Date.CultureInfo.formatPatterns.longDatePattern) }; Date.prototype.toShortTimeString = function () { return this.toString(Date.CultureInfo.formatPatterns.shortTimePattern) }; Date.prototype.toLongTimeString = function () { return this.toString(Date.CultureInfo.formatPatterns.longTimePattern) }; Date.prototype.getOrdinal = (function () {
+  switch (this.getDate()) {
+    case 1:
     case 21:
     case 31:
-      return 'st';case 2:
+      return 'st'; case 2:
     case 22:
-      return 'nd';case 3:
+      return 'nd'; case 3:
     case 23:
-      return 'rd';default:
-      return 'th';}}(function () {Date.Parsing = {Exception: function (s) {this.message = "Parse error at '" + s.substring(0, 10) + " ...'";}};var $P = Date.Parsing
-  var _ = $P.Operators = {rtoken: function (r) {return function (s) {var mx = s.match(r)
-        if (mx) {return ([mx[0], s.substring(mx[0].length)]);}else {throw new $P.Exception(s);}};},token: function (s) {return function (s) {return _.rtoken(new RegExp('^\s*' + s + '\s*'))(s);};},stoken: function (s) {return _.rtoken(new RegExp('^' + s));},until: function (p) {return function (s) {var qx = [],rx = null
-        while(s.length){try {rx = p.call(this, s);} catch(e) {qx.push(rx[0]);s = rx[1];continue; }
-          break;}
-        return [qx, s];};},many: function (p) {return function (s) {var rx = [],r = null
-        while(s.length){try {r = p.call(this, s);} catch(e) {return [rx, s]; }
-          rx.push(r[0]);s = r[1];}
-        return [rx, s];};},optional: function (p) {return function (s) {var r = null
-        try {r = p.call(this, s);} catch(e) {return [null, s]; }
-        return [r[0], r[1]];};},not: function (p) {return function (s) {try {p.call(this, s);} catch(e) {return [null, s]; }
-        throw new $P.Exception(s);};},ignore: function (p) {return p ? function (s) {var r = null
-        r = p.call(this, s);return [null, r[1]];} : null;},product: function () {var px = arguments[0],qx = Array.prototype.slice.call(arguments, 1),rx = []
-      for (var i = 0;i < px.length;i++) {rx.push(_.each(px[i], qx));}
-      return rx;},cache: function (rule) {var cache = {},r = null
-      return function (s) {try {r = cache[s] = (cache[s] || rule.call(this, s));} catch(e) {r = cache[s] = e; }
-        if (r instanceof $P.Exception) {throw r;}else {return r;}};},any: function () {var px = arguments
-      return function (s) {var r = null
-        for (var i = 0;i < px.length;i++) {if (px[i] == null) {continue;}
-          try {r = (px[i].call(this, s));} catch(e) {r = null; }
-          if (r) {return r;}}
-        throw new $P.Exception(s);};},each: function () {var px = arguments
-      return function (s) {var rx = [],r = null
-        for (var i = 0;i < px.length;i++) {if (px[i] == null) {continue;}
-          try {r = (px[i].call(this, s));} catch(e) {throw new $P.Exception(s); }
-          rx.push(r[0]);s = r[1];}
-        return [rx, s];};},all: function () {var px = arguments,_ = _
-      return _.each(_.optional(px));},sequence: function (px, d, c) {d = d || _.rtoken(/^\s*/);c = c || null;if (px.length == 1) {return px[0];}
-      return function (s) {var r = null,q = null
+      return 'rd'; default:
+      return 'th'
+  }
+}(function () {
+  Date.Parsing = {Exception: function (s) { this.message = "Parse error at '" + s.substring(0, 10) + " ...'" }}; var $P = Date.Parsing
+  var _ = $P.Operators = {rtoken: function (r) {
+    return function (s) {
+      var mx = s.match(r)
+      if (mx) { return ([mx[0], s.substring(mx[0].length)]) } else { throw new $P.Exception(s) }
+    }
+  },
+    token: function (s) { return function (s) { return _.rtoken(new RegExp('^\s*' + s + '\s*'))(s) } },
+    stoken: function (s) { return _.rtoken(new RegExp('^' + s)) },
+    until: function (p) {
+      return function (s) {
+        var qx = [], rx = null
+        while (s.length) {
+          try { rx = p.call(this, s) } catch (e) { qx.push(rx[0]); s = rx[1]; continue }
+          break
+        }
+        return [qx, s]
+      }
+    },
+    many: function (p) {
+      return function (s) {
+        var rx = [], r = null
+        while (s.length) {
+          try { r = p.call(this, s) } catch (e) { return [rx, s] }
+          rx.push(r[0]); s = r[1]
+        }
+        return [rx, s]
+      }
+    },
+    optional: function (p) {
+      return function (s) {
+        var r = null
+        try { r = p.call(this, s) } catch (e) { return [null, s] }
+        return [r[0], r[1]]
+      }
+    },
+    not: function (p) {
+      return function (s) {
+        try { p.call(this, s) } catch (e) { return [null, s] }
+        throw new $P.Exception(s)
+      }
+    },
+    ignore: function (p) {
+      return p ? function (s) {
+        var r = null
+        r = p.call(this, s); return [null, r[1]]
+      } : null
+    },
+    product: function () {
+      var px = arguments[0], qx = Array.prototype.slice.call(arguments, 1), rx = []
+      for (var i = 0; i < px.length; i++) { rx.push(_.each(px[i], qx)) }
+      return rx
+    },
+    cache: function (rule) {
+      var cache = {}, r = null
+      return function (s) {
+        try { r = cache[s] = (cache[s] || rule.call(this, s)) } catch (e) { r = cache[s] = e }
+        if (r instanceof $P.Exception) { throw r } else { return r }
+      }
+    },
+    any: function () {
+      var px = arguments
+      return function (s) {
+        var r = null
+        for (var i = 0; i < px.length; i++) {
+          if (px[i] == null) { continue }
+          try { r = (px[i].call(this, s)) } catch (e) { r = null }
+          if (r) { return r }
+        }
+        throw new $P.Exception(s)
+      }
+    },
+    each: function () {
+      var px = arguments
+      return function (s) {
+        var rx = [], r = null
+        for (var i = 0; i < px.length; i++) {
+          if (px[i] == null) { continue }
+          try { r = (px[i].call(this, s)) } catch (e) { throw new $P.Exception(s) }
+          rx.push(r[0]); s = r[1]
+        }
+        return [rx, s]
+      }
+    },
+    all: function () {
+      var px = arguments, _ = _
+      return _.each(_.optional(px))
+    },
+    sequence: function (px, d, c) {
+      d = d || _.rtoken(/^\s*/); c = c || null; if (px.length == 1) { return px[0] }
+      return function (s) {
+        var r = null, q = null
         var rx = []
-        for (var i = 0;i < px.length;i++) {try {r = px[i].call(this, s);} catch(e) {break; }
-          rx.push(r[0]);try {q = d.call(this, r[1]);} catch(ex) {q = null;break; }
-          s = q[1];}
-        if (!r) {throw new $P.Exception(s);}
-        if (q) {throw new $P.Exception(q[1]);}
-        if (c) {try {r = c.call(this, r[1]);} catch(ey) {throw new $P.Exception(r[1]); }}
-        return [rx,(r ? r[1] : s)];};},between: function (d1, p, d2) {d2 = d2 || d1;var _fn = _.each(_.ignore(d1), p, _.ignore(d2))
-      return function (s) {var rx = _fn.call(this, s)
-        return [[rx[0][0], r[0][2]], rx[1]];};},list: function (p, d, c) {d = d || _.rtoken(/^\s*/);c = c || null;return (p instanceof Array ? _.each(_.product(p.slice(0, -1), _.ignore(d)), p.slice(-1), _.ignore(c)) : _.each(_.many(_.each(p, _.ignore(d))), px, _.ignore(c)));},set: function (px, d, c) {d = d || _.rtoken(/^\s*/);c = c || null;return function (s) {var r = null,p = null,q = null,rx = null,best = [[], s],last = false
-        for (var i = 0;i < px.length;i++) {q = null;p = null;r = null;last = (px.length == 1);try {r = px[i].call(this, s);} catch(e) {continue; }
-          rx = [[r[0]], r[1]];if (r[1].length > 0 && !last) {try {q = d.call(this, r[1]);} catch(ex) {last = true; }}else {last = true;}
-          if (!last && q[1].length === 0) {last = true;}
-          if (!last) {var qx = []
-            for (var j = 0;j < px.length;j++) {if (i != j) {qx.push(px[j]);}}
-            p = _.set(qx, d).call(this, q[1]);if (p[0].length > 0) {rx[0] = rx[0].concat(p[0]);rx[1] = p[1];}}
-          if (rx[1].length < best[1].length) {best = rx;}
-          if (best[1].length === 0) {break;}}
-        if (best[0].length === 0) {return best;}
-        if (c) {try {q = c.call(this, best[1]);} catch(ey) {throw new $P.Exception(best[1]); }
-          best[1] = q[1];}
-        return best;};},forward: function (gr, fname) {return function (s) {return gr[fname].call(this, s);};},replace: function (rule, repl) {return function (s) {var r = rule.call(this, s)
-        return [repl, r[1]];};},process: function (rule, fn) {return function (s) {var r = rule.call(this, s)
-        return [fn.call(this, r[0]), r[1]];};},min: function (min, rule) {return function (s) {var rx = rule.call(this, s)
-        if (rx[0].length < min) {throw new $P.Exception(s);}
-      return rx;};}}
-  var _generator = function (op) {return function () {var args = null,rx = []
-      if (arguments.length > 1) {args = Array.prototype.slice.call(arguments);}else if (arguments[0] instanceof Array) {args = arguments[0];}
-      if (args) { for (var i = 0,px = args.shift();i < px.length;i++) {args.unshift(px[i]);rx.push(op.apply(null, args));args.shift();return rx;}}else {return op.apply(null, arguments);}};}
+        for (var i = 0; i < px.length; i++) {
+          try { r = px[i].call(this, s) } catch (e) { break }
+          rx.push(r[0]); try { q = d.call(this, r[1]) } catch (ex) { q = null; break }
+          s = q[1]
+        }
+        if (!r) { throw new $P.Exception(s) }
+        if (q) { throw new $P.Exception(q[1]) }
+        if (c) { try { r = c.call(this, r[1]) } catch (ey) { throw new $P.Exception(r[1]) } }
+        return [rx, (r ? r[1] : s)]
+      }
+    },
+    between: function (d1, p, d2) {
+      d2 = d2 || d1; var _fn = _.each(_.ignore(d1), p, _.ignore(d2))
+      return function (s) {
+        var rx = _fn.call(this, s)
+        return [[rx[0][0], r[0][2]], rx[1]]
+      }
+    },
+    list: function (p, d, c) { d = d || _.rtoken(/^\s*/); c = c || null; return (p instanceof Array ? _.each(_.product(p.slice(0, -1), _.ignore(d)), p.slice(-1), _.ignore(c)) : _.each(_.many(_.each(p, _.ignore(d))), px, _.ignore(c))) },
+    set: function (px, d, c) {
+      d = d || _.rtoken(/^\s*/); c = c || null; return function (s) {
+        var r = null, p = null, q = null, rx = null, best = [[], s], last = false
+        for (var i = 0; i < px.length; i++) {
+          q = null; p = null; r = null; last = (px.length == 1); try { r = px[i].call(this, s) } catch (e) { continue }
+          rx = [[r[0]], r[1]]; if (r[1].length > 0 && !last) { try { q = d.call(this, r[1]) } catch (ex) { last = true } } else { last = true }
+          if (!last && q[1].length === 0) { last = true }
+          if (!last) {
+            var qx = []
+            for (var j = 0; j < px.length; j++) { if (i != j) { qx.push(px[j]) } }
+            p = _.set(qx, d).call(this, q[1]); if (p[0].length > 0) { rx[0] = rx[0].concat(p[0]); rx[1] = p[1] }
+          }
+          if (rx[1].length < best[1].length) { best = rx }
+          if (best[1].length === 0) { break }
+        }
+        if (best[0].length === 0) { return best }
+        if (c) {
+          try { q = c.call(this, best[1]) } catch (ey) { throw new $P.Exception(best[1]) }
+          best[1] = q[1]
+        }
+        return best
+      }
+    },
+    forward: function (gr, fname) { return function (s) { return gr[fname].call(this, s) } },
+    replace: function (rule, repl) {
+      return function (s) {
+        var r = rule.call(this, s)
+        return [repl, r[1]]
+      }
+    },
+    process: function (rule, fn) {
+      return function (s) {
+        var r = rule.call(this, s)
+        return [fn.call(this, r[0]), r[1]]
+      }
+    },
+    min: function (min, rule) {
+      return function (s) {
+        var rx = rule.call(this, s)
+        if (rx[0].length < min) { throw new $P.Exception(s) }
+        return rx
+      }
+    }}
+  var _generator = function (op) {
+    return function () {
+      var args = null, rx = []
+      if (arguments.length > 1) { args = Array.prototype.slice.call(arguments) } else if (arguments[0] instanceof Array) { args = arguments[0] }
+      if (args) { for (var i = 0, px = args.shift(); i < px.length; i++) { args.unshift(px[i]); rx.push(op.apply(null, args)); args.shift(); return rx } } else { return op.apply(null, arguments) }
+    }
+  }
   var gx = 'optional not ignore cache'.split(/\s/)
-  for (var i = 0;i < gx.length;i++) {_[gx[i]] = _generator(_[gx[i]]);}
-  var _vector = function (op) {return function () {if (arguments[0] instanceof Array) {return op.apply(null, arguments[0]);}else {return op.apply(null, arguments);}};}
+  for (var i = 0; i < gx.length; i++) { _[gx[i]] = _generator(_[gx[i]]) }
+  var _vector = function (op) { return function () { if (arguments[0] instanceof Array) { return op.apply(null, arguments[0]) } else { return op.apply(null, arguments) } } }
   var vx = 'each any all'.split(/\s/)
-  for (var j = 0;j < vx.length;j++) {_[vx[j]] = _vector(_[vx[j]]);}}())
-;(function () {var flattenAndCompact = function (ax) {var rx = []
-    for (var i = 0;i < ax.length;i++) {if (ax[i] instanceof Array) {rx = rx.concat(flattenAndCompact(ax[i]));}else {if (ax[i]) {rx.push(ax[i]);}}}
-    return rx;}
-  Date.Grammar = {};Date.Translator = {hour: function (s) {return function () {this.hour = Number(s);};},minute: function (s) {return function () {this.minute = Number(s);};},second: function (s) {return function () {this.second = Number(s);};},meridian: function (s) {return function () {this.meridian = s.slice(0, 1).toLowerCase();};},timezone: function (s) {return function () {var n = s.replace(/[^\d\+\-]/g, '')
-        if (n.length) {this.timezoneOffset = Number(n);}else {this.timezone = s.toLowerCase();}};},day: function (x) {var s = x[0]
-      return function () {this.day = Number(s.match(/\d+/)[0]);};},month: function (s) {return function () {this.month = ((s.length == 3) ? Date.getMonthNumberFromName(s) : (Number(s) - 1));};},year: function (s) {return function () {var n = Number(s)
-        this.year = ((s.length > 2) ? n : (n + (((n + 2000) < Date.CultureInfo.twoDigitYearMax) ? 2000 : 1900)));};},rday: function (s) {return function () {switch (s) {case 'yesterday':
+  for (var j = 0; j < vx.length; j++) { _[vx[j]] = _vector(_[vx[j]]) }
+}()))
+;(function () {
+  var flattenAndCompact = function (ax) {
+    var rx = []
+    for (var i = 0; i < ax.length; i++) { if (ax[i] instanceof Array) { rx = rx.concat(flattenAndCompact(ax[i])) } else { if (ax[i]) { rx.push(ax[i]) } } }
+    return rx
+  }
+  Date.Grammar = {}; Date.Translator = {hour: function (s) { return function () { this.hour = Number(s) } },
+    minute: function (s) { return function () { this.minute = Number(s) } },
+    second: function (s) { return function () { this.second = Number(s) } },
+    meridian: function (s) { return function () { this.meridian = s.slice(0, 1).toLowerCase() } },
+    timezone: function (s) {
+      return function () {
+        var n = s.replace(/[^\d\+\-]/g, '')
+        if (n.length) { this.timezoneOffset = Number(n) } else { this.timezone = s.toLowerCase() }
+      }
+    },
+    day: function (x) {
+      var s = x[0]
+      return function () { this.day = Number(s.match(/\d+/)[0]) }
+    },
+    month: function (s) { return function () { this.month = ((s.length == 3) ? Date.getMonthNumberFromName(s) : (Number(s) - 1)) } },
+    year: function (s) {
+      return function () {
+        var n = Number(s)
+        this.year = ((s.length > 2) ? n : (n + (((n + 2000) < Date.CultureInfo.twoDigitYearMax) ? 2000 : 1900)))
+      }
+    },
+    rday: function (s) {
+      return function () {
+        switch (s) {
+          case 'yesterday':
             this.days = -1
-            break;case 'tomorrow':
+            break; case 'tomorrow':
             this.days = 1
-            break;case 'today':
+            break; case 'today':
             this.days = 0
-            break;case 'now':
-            this.days = 0;this.now = true
-            break;}};},finishExact: function (x) {x = (x instanceof Array) ? x : [x];var now = new Date()
-      this.year = now.getFullYear();this.month = now.getMonth();this.day = 1;this.hour = 0;this.minute = 0;this.second = 0; for (var i = 0;i < x.length;i++) {if (x[i]) {x[i].call(this);}}
-      this.hour = (this.meridian == 'p' && this.hour < 13) ? this.hour + 12 : this.hour;if (this.day > Date.getDaysInMonth(this.year, this.month)) {throw new RangeError(this.day + ' is not a valid value for days.');}
+            break; case 'now':
+            this.days = 0; this.now = true
+            break
+        }
+      }
+    },
+    finishExact: function (x) {
+      x = (x instanceof Array) ? x : [x]; var now = new Date()
+      this.year = now.getFullYear(); this.month = now.getMonth(); this.day = 1; this.hour = 0; this.minute = 0; this.second = 0; for (var i = 0; i < x.length; i++) { if (x[i]) { x[i].call(this) } }
+      this.hour = (this.meridian == 'p' && this.hour < 13) ? this.hour + 12 : this.hour; if (this.day > Date.getDaysInMonth(this.year, this.month)) { throw new RangeError(this.day + ' is not a valid value for days.') }
       var r = new Date(this.year, this.month, this.day, this.hour, this.minute, this.second)
-      if (this.timezone) {r.set({timezone: this.timezone});}else if (this.timezoneOffset) {r.set({timezoneOffset: this.timezoneOffset});}
-      return r;},finish: function (x) {x = (x instanceof Array) ? flattenAndCompact(x) : [x];if (x.length === 0) {return null;}
-      for (var i = 0;i < x.length;i++) {if (typeof x[i] == 'function') {x[i].call(this);}}
-      if (this.now) {return new Date();}
+      if (this.timezone) { r.set({timezone: this.timezone}) } else if (this.timezoneOffset) { r.set({timezoneOffset: this.timezoneOffset}) }
+      return r
+    },
+    finish: function (x) {
+      x = (x instanceof Array) ? flattenAndCompact(x) : [x]; if (x.length === 0) { return null }
+      for (var i = 0; i < x.length; i++) { if (typeof x[i] === 'function') { x[i].call(this) } }
+      if (this.now) { return new Date() }
       var today = Date.today()
       var method = null
       var expression = !!(this.days != null || this.orient || this.operator)
-      if (expression) {var gap,mod,orient
-        orient = ((this.orient == 'past' || this.operator == 'subtract') ? -1 : 1);if (this.weekday) {this.unit = 'day';gap = (Date.getDayNumberFromName(this.weekday) - today.getDay());mod = 7;this.days = gap ? ((gap + (orient * mod)) % mod) : (orient * mod);}
-        if (this.month) {this.unit = 'month';gap = (this.month - today.getMonth());mod = 12;this.months = gap ? ((gap + (orient * mod)) % mod) : (orient * mod);this.month = null;}
-        if (!this.unit) {this.unit = 'day';}
-        if (this[this.unit + 's'] == null || this.operator != null) {if (!this.value) {this.value = 1;}
-          if (this.unit == 'week') {this.unit = 'day';this.value = this.value * 7;}
-          this[this.unit + 's'] = this.value * orient;}
-        return today.add(this);}else {if (this.meridian && this.hour) {this.hour = (this.hour < 13 && this.meridian == 'p') ? this.hour + 12 : this.hour;}
-        if (this.weekday && !this.day) {this.day = (today.addDays((Date.getDayNumberFromName(this.weekday) - today.getDay()))).getDate();}
-        if (this.month && !this.day) {this.day = 1;}
-      return today.set(this);}}};var _ = Date.Parsing.Operators,g = Date.Grammar,t = Date.Translator,_fn
-  g.datePartDelimiter = _.rtoken(/^([\s\-\.\,\/\x27]+)/);g.timePartDelimiter = _.stoken(':');g.whiteSpace = _.rtoken(/^\s*/);g.generalDelimiter = _.rtoken(/^(([\s\,]|at|on)+)/);var _C = {}
-  g.ctoken = function (keys) {var fn = _C[keys]
-    if (!fn) {var c = Date.CultureInfo.regexPatterns
-      var kx = keys.split(/\s+/),px = []
-      for (var i = 0;i < kx.length;i++) {px.push(_.replace(_.rtoken(c[kx[i]]), kx[i]));}
-      fn = _C[keys] = _.any.apply(null, px);}
-    return fn;};g.ctoken2 = function (key) {return _.rtoken(Date.CultureInfo.regexPatterns[key]);};g.h = _.cache(_.process(_.rtoken(/^(0[0-9]|1[0-2]|[1-9])/), t.hour));g.hh = _.cache(_.process(_.rtoken(/^(0[0-9]|1[0-2])/), t.hour));g.H = _.cache(_.process(_.rtoken(/^([0-1][0-9]|2[0-3]|[0-9])/), t.hour));g.HH = _.cache(_.process(_.rtoken(/^([0-1][0-9]|2[0-3])/), t.hour));g.m = _.cache(_.process(_.rtoken(/^([0-5][0-9]|[0-9])/), t.minute));g.mm = _.cache(_.process(_.rtoken(/^[0-5][0-9]/), t.minute));g.s = _.cache(_.process(_.rtoken(/^([0-5][0-9]|[0-9])/), t.second));g.ss = _.cache(_.process(_.rtoken(/^[0-5][0-9]/), t.second));g.hms = _.cache(_.sequence([g.H, g.mm, g.ss], g.timePartDelimiter));g.t = _.cache(_.process(g.ctoken2('shortMeridian'), t.meridian));g.tt = _.cache(_.process(g.ctoken2('longMeridian'), t.meridian));g.z = _.cache(_.process(_.rtoken(/^(\+|\-)?\s*\d\d\d\d?/), t.timezone));g.zz = _.cache(_.process(_.rtoken(/^(\+|\-)\s*\d\d\d\d/), t.timezone));g.zzz = _.cache(_.process(g.ctoken2('timezone'), t.timezone));g.timeSuffix = _.each(_.ignore(g.whiteSpace), _.set([g.tt, g.zzz]));g.time = _.each(_.optional(_.ignore(_.stoken('T'))), g.hms, g.timeSuffix);g.d = _.cache(_.process(_.each(_.rtoken(/^([0-2]\d|3[0-1]|\d)/), _.optional(g.ctoken2('ordinalSuffix'))), t.day));g.dd = _.cache(_.process(_.each(_.rtoken(/^([0-2]\d|3[0-1])/), _.optional(g.ctoken2('ordinalSuffix'))), t.day));g.ddd = g.dddd = _.cache(_.process(g.ctoken('sun mon tue wed thu fri sat'), function (s) {return function () {this.weekday = s;};}));g.M = _.cache(_.process(_.rtoken(/^(1[0-2]|0\d|\d)/), t.month));g.MM = _.cache(_.process(_.rtoken(/^(1[0-2]|0\d)/), t.month));g.MMM = g.MMMM = _.cache(_.process(g.ctoken('jan feb mar apr may jun jul aug sep oct nov dec'), t.month));g.y = _.cache(_.process(_.rtoken(/^(\d\d?)/), t.year));g.yy = _.cache(_.process(_.rtoken(/^(\d\d)/), t.year));g.yyy = _.cache(_.process(_.rtoken(/^(\d\d?\d?\d?)/), t.year));g.yyyy = _.cache(_.process(_.rtoken(/^(\d\d\d\d)/), t.year));_fn = function () {return _.each(_.any.apply(null, arguments), _.not(g.ctoken2('timeContext')));};g.day = _fn(g.d, g.dd);g.month = _fn(g.M, g.MMM);g.year = _fn(g.yyyy, g.yy);g.orientation = _.process(g.ctoken('past future'), function (s) {return function () {this.orient = s;};});g.operator = _.process(g.ctoken('add subtract'), function (s) {return function () {this.operator = s;};});g.rday = _.process(g.ctoken('yesterday tomorrow today now'), t.rday);g.unit = _.process(g.ctoken('minute hour day week month year'), function (s) {return function () {this.unit = s;};});g.value = _.process(_.rtoken(/^\d\d?(st|nd|rd|th)?/), function (s) {return function () {this.value = s.replace(/\D/g, '');};});g.expression = _.set([g.rday, g.operator, g.value, g.unit, g.orientation, g.ddd, g.MMM]);_fn = function () {return _.set(arguments, g.datePartDelimiter);};g.mdy = _fn(g.ddd, g.month, g.day, g.year);g.ymd = _fn(g.ddd, g.year, g.month, g.day);g.dmy = _fn(g.ddd, g.day, g.month, g.year);g.date = function (s) {return ((g[Date.CultureInfo.dateElementOrder] || g.mdy).call(this, s));};g.format = _.process(_.many(_.any(_.process(_.rtoken(/^(dd?d?d?|MM?M?M?|yy?y?y?|hh?|HH?|mm?|ss?|tt?|zz?z?)/), function (fmt) {if (g[fmt]) {return g[fmt];}else {throw Date.Parsing.Exception(fmt);}}), _.process(_.rtoken(/^[^dMyhHmstz]+/), function (s) {return _.ignore(_.stoken(s));}))), function (rules) {return _.process(_.each.apply(null, rules), t.finishExact);});var _F = {}
-  var _get = function (f) {return _F[f] = (_F[f] || g.format(f)[0]);}
-  g.formats = function (fx) {if (fx instanceof Array) {var rx = []
-      for (var i = 0;i < fx.length;i++) {rx.push(_get(fx[i]));}
-      return _.any.apply(null, rx);}else {return _get(fx);}};g._formats = g.formats(['yyyy-MM-ddTHH:mm:ss', 'ddd, MMM dd, yyyy H:mm:ss tt', 'ddd MMM d yyyy HH:mm:ss zzz', 'd']);g._start = _.process(_.set([g.date, g.time, g.expression], g.generalDelimiter, g.whiteSpace), t.finish);g.start = function (s) {try {var r = g._formats.call({}, s)
-      if (r[1].length === 0) {return r;}} catch(e) {}
-    return g._start.call({}, s);};}());Date._parse = Date.parse;Date.parse = function (s) {var r = null
-  if (!s) {return null;}
-  try {r = Date.Grammar.start.call({}, s);} catch(e) {return null; }
-  return ((r[1].length === 0) ? r[0] : null);};Date.getParseFunction = function (fx) {var fn = Date.Grammar.formats(fx)
-  return function (s) {var r = null
-    try {r = fn.call({}, s);} catch(e) {return null; }
-    return ((r[1].length === 0) ? r[0] : null);};};Date.parseExact = function (s, fx) {return Date.getParseFunction(fx)(s);}
+      if (expression) {
+        var gap, mod, orient
+        orient = ((this.orient == 'past' || this.operator == 'subtract') ? -1 : 1); if (this.weekday) { this.unit = 'day'; gap = (Date.getDayNumberFromName(this.weekday) - today.getDay()); mod = 7; this.days = gap ? ((gap + (orient * mod)) % mod) : (orient * mod) }
+        if (this.month) { this.unit = 'month'; gap = (this.month - today.getMonth()); mod = 12; this.months = gap ? ((gap + (orient * mod)) % mod) : (orient * mod); this.month = null }
+        if (!this.unit) { this.unit = 'day' }
+        if (this[this.unit + 's'] == null || this.operator != null) {
+          if (!this.value) { this.value = 1 }
+          if (this.unit == 'week') { this.unit = 'day'; this.value = this.value * 7 }
+          this[this.unit + 's'] = this.value * orient
+        }
+        return today.add(this)
+      } else {
+        if (this.meridian && this.hour) { this.hour = (this.hour < 13 && this.meridian == 'p') ? this.hour + 12 : this.hour }
+        if (this.weekday && !this.day) { this.day = (today.addDays((Date.getDayNumberFromName(this.weekday) - today.getDay()))).getDate() }
+        if (this.month && !this.day) { this.day = 1 }
+        return today.set(this)
+      }
+    }}; var _ = Date.Parsing.Operators, g = Date.Grammar, t = Date.Translator, _fn
+  g.datePartDelimiter = _.rtoken(/^([\s\-\.\,\/\x27]+)/); g.timePartDelimiter = _.stoken(':'); g.whiteSpace = _.rtoken(/^\s*/); g.generalDelimiter = _.rtoken(/^(([\s\,]|at|on)+)/); var _C = {}
+  g.ctoken = function (keys) {
+    var fn = _C[keys]
+    if (!fn) {
+      var c = Date.CultureInfo.regexPatterns
+      var kx = keys.split(/\s+/), px = []
+      for (var i = 0; i < kx.length; i++) { px.push(_.replace(_.rtoken(c[kx[i]]), kx[i])) }
+      fn = _C[keys] = _.any.apply(null, px)
+    }
+    return fn
+  }; g.ctoken2 = function (key) { return _.rtoken(Date.CultureInfo.regexPatterns[key]) }; g.h = _.cache(_.process(_.rtoken(/^(0[0-9]|1[0-2]|[1-9])/), t.hour)); g.hh = _.cache(_.process(_.rtoken(/^(0[0-9]|1[0-2])/), t.hour)); g.H = _.cache(_.process(_.rtoken(/^([0-1][0-9]|2[0-3]|[0-9])/), t.hour)); g.HH = _.cache(_.process(_.rtoken(/^([0-1][0-9]|2[0-3])/), t.hour)); g.m = _.cache(_.process(_.rtoken(/^([0-5][0-9]|[0-9])/), t.minute)); g.mm = _.cache(_.process(_.rtoken(/^[0-5][0-9]/), t.minute)); g.s = _.cache(_.process(_.rtoken(/^([0-5][0-9]|[0-9])/), t.second)); g.ss = _.cache(_.process(_.rtoken(/^[0-5][0-9]/), t.second)); g.hms = _.cache(_.sequence([g.H, g.mm, g.ss], g.timePartDelimiter)); g.t = _.cache(_.process(g.ctoken2('shortMeridian'), t.meridian)); g.tt = _.cache(_.process(g.ctoken2('longMeridian'), t.meridian)); g.z = _.cache(_.process(_.rtoken(/^(\+|\-)?\s*\d\d\d\d?/), t.timezone)); g.zz = _.cache(_.process(_.rtoken(/^(\+|\-)\s*\d\d\d\d/), t.timezone)); g.zzz = _.cache(_.process(g.ctoken2('timezone'), t.timezone)); g.timeSuffix = _.each(_.ignore(g.whiteSpace), _.set([g.tt, g.zzz])); g.time = _.each(_.optional(_.ignore(_.stoken('T'))), g.hms, g.timeSuffix); g.d = _.cache(_.process(_.each(_.rtoken(/^([0-2]\d|3[0-1]|\d)/), _.optional(g.ctoken2('ordinalSuffix'))), t.day)); g.dd = _.cache(_.process(_.each(_.rtoken(/^([0-2]\d|3[0-1])/), _.optional(g.ctoken2('ordinalSuffix'))), t.day)); g.ddd = g.dddd = _.cache(_.process(g.ctoken('sun mon tue wed thu fri sat'), function (s) { return function () { this.weekday = s } })); g.M = _.cache(_.process(_.rtoken(/^(1[0-2]|0\d|\d)/), t.month)); g.MM = _.cache(_.process(_.rtoken(/^(1[0-2]|0\d)/), t.month)); g.MMM = g.MMMM = _.cache(_.process(g.ctoken('jan feb mar apr may jun jul aug sep oct nov dec'), t.month)); g.y = _.cache(_.process(_.rtoken(/^(\d\d?)/), t.year)); g.yy = _.cache(_.process(_.rtoken(/^(\d\d)/), t.year)); g.yyy = _.cache(_.process(_.rtoken(/^(\d\d?\d?\d?)/), t.year)); g.yyyy = _.cache(_.process(_.rtoken(/^(\d\d\d\d)/), t.year)); _fn = function () { return _.each(_.any.apply(null, arguments), _.not(g.ctoken2('timeContext'))) }; g.day = _fn(g.d, g.dd); g.month = _fn(g.M, g.MMM); g.year = _fn(g.yyyy, g.yy); g.orientation = _.process(g.ctoken('past future'), function (s) { return function () { this.orient = s } }); g.operator = _.process(g.ctoken('add subtract'), function (s) { return function () { this.operator = s } }); g.rday = _.process(g.ctoken('yesterday tomorrow today now'), t.rday); g.unit = _.process(g.ctoken('minute hour day week month year'), function (s) { return function () { this.unit = s } }); g.value = _.process(_.rtoken(/^\d\d?(st|nd|rd|th)?/), function (s) { return function () { this.value = s.replace(/\D/g, '') } }); g.expression = _.set([g.rday, g.operator, g.value, g.unit, g.orientation, g.ddd, g.MMM]); _fn = function () { return _.set(arguments, g.datePartDelimiter) }; g.mdy = _fn(g.ddd, g.month, g.day, g.year); g.ymd = _fn(g.ddd, g.year, g.month, g.day); g.dmy = _fn(g.ddd, g.day, g.month, g.year); g.date = function (s) { return ((g[Date.CultureInfo.dateElementOrder] || g.mdy).call(this, s)) }; g.format = _.process(_.many(_.any(_.process(_.rtoken(/^(dd?d?d?|MM?M?M?|yy?y?y?|hh?|HH?|mm?|ss?|tt?|zz?z?)/), function (fmt) { if (g[fmt]) { return g[fmt] } else { throw Date.Parsing.Exception(fmt) } }), _.process(_.rtoken(/^[^dMyhHmstz]+/), function (s) { return _.ignore(_.stoken(s)) }))), function (rules) { return _.process(_.each.apply(null, rules), t.finishExact) }); var _F = {}
+  var _get = function (f) { return _F[f] = (_F[f] || g.format(f)[0]) }
+  g.formats = function (fx) {
+    if (fx instanceof Array) {
+      var rx = []
+      for (var i = 0; i < fx.length; i++) { rx.push(_get(fx[i])) }
+      return _.any.apply(null, rx)
+    } else { return _get(fx) }
+  }; g._formats = g.formats(['yyyy-MM-ddTHH:mm:ss', 'ddd, MMM dd, yyyy H:mm:ss tt', 'ddd MMM d yyyy HH:mm:ss zzz', 'd']); g._start = _.process(_.set([g.date, g.time, g.expression], g.generalDelimiter, g.whiteSpace), t.finish); g.start = function (s) {
+    try {
+      var r = g._formats.call({}, s)
+      if (r[1].length === 0) { return r }
+    } catch (e) {}
+    return g._start.call({}, s)
+  }
+}()); Date._parse = Date.parse; Date.parse = function (s) {
+  var r = null
+  if (!s) { return null }
+  try { r = Date.Grammar.start.call({}, s) } catch (e) { return null }
+  return ((r[1].length === 0) ? r[0] : null)
+}; Date.getParseFunction = function (fx) {
+  var fn = Date.Grammar.formats(fx)
+  return function (s) {
+    var r = null
+    try { r = fn.call({}, s) } catch (e) { return null }
+    return ((r[1].length === 0) ? r[0] : null)
+  }
+}; Date.parseExact = function (s, fx) { return Date.getParseFunction(fx)(s) }

--- a/js/decryptPage.js
+++ b/js/decryptPage.js
@@ -11,7 +11,7 @@ if (content == 'dummy') { // used if page contains encrypted content and not fie
 var decryptedContent
 try {
   decryptedContent = $.rc4DecryptStr(content, key)
-} catch(err) {
+} catch (err) {
   decryptedContent = '(Decryption error)'
 }
 

--- a/js/decryptPage.js
+++ b/js/decryptPage.js
@@ -1,8 +1,8 @@
 var key = params['k']
 var content = params['c']
-if (content == 'dummy') { // used if page contains encrypted content and not field
+if (content === 'dummy') { // used if page contains encrypted content and not field
   content = $('body').html()
-  if (content.indexOf('\n') != -1) {
+  if (content.indexOf('\n') !== -1) {
     var ary = content.split('\n')
     content = ary[0]
   }

--- a/js/encryptPage.js
+++ b/js/encryptPage.js
@@ -19,13 +19,20 @@ function convertImagesToBase64 () {
 
     var context = canvas.getContext('2d')
     var newImage = new Image()
-    newImage.src
+    // newImage.src
     // context.drawImage(img,0,0)
     console.log(i + ': ' + images[i].src + '  file type: ' + fileType)
     var fileType = images[i].src.substr(images[i].src.length - 4).toLowerCase()
-    if (fileType == '.jpg' || fileType == 'jpeg') { fileType = 'image/jpeg' } else if (fileType == '.png') { fileType = 'image/png' } else if (fileType == '.gif') { fileType = 'image/gif' } else {
+    if (fileType === '.jpg' || fileType === 'jpeg') {
+      fileType = 'image/jpeg'
+    } else if (fileType === '.png') {
+      fileType = 'image/png'
+    } else if (fileType === '.gif') {
+      fileType = 'image/gif'
+    } else {
       var uTransformed = images[i].src.substring(0, images[i].src.indexOf('.jpg')) + '.jpg'
-      alert('error at image ' + i + ' ' + uTransformed); continue; console.log(uTransformed); return
+      alert('error at image ' + i + ' ' + uTransformed)
+      continue
     }
     console.log(i + ': ' + images[i].src + '  file type: ' + fileType)
 
@@ -38,8 +45,8 @@ function convertImagesToBase64 () {
       // alert(base64)
       // img.src = base64;//"https://www.google.com/intl/en_com/images/srpr/logo3w.png"
 
-    // chrome.extension.sendRequest({url: img.src})
-    // chrome.extension.getBackgroundPage().adjustImage(img.src)
+      // chrome.extension.sendRequest({url: img.src})
+      // chrome.extension.getBackgroundPage().adjustImage(img.src)
     } catch (e) {
       console.log(e)
       return

--- a/js/encryptPage.js
+++ b/js/encryptPage.js
@@ -23,11 +23,10 @@ function convertImagesToBase64 () {
     // context.drawImage(img,0,0)
     console.log(i + ': ' + images[i].src + '  file type: ' + fileType)
     var fileType = images[i].src.substr(images[i].src.length - 4).toLowerCase()
-    if (fileType == '.jpg' || fileType == 'jpeg') {fileType = 'image/jpeg';}
-    else if (fileType == '.png') {fileType = 'image/png';}
-    else if (fileType == '.gif') {fileType = 'image/gif';}else {
+    if (fileType == '.jpg' || fileType == 'jpeg') { fileType = 'image/jpeg' } else if (fileType == '.png') { fileType = 'image/png' } else if (fileType == '.gif') { fileType = 'image/gif' } else {
       var uTransformed = images[i].src.substring(0, images[i].src.indexOf('.jpg')) + '.jpg'
-      alert('error at image ' + i + ' ' + uTransformed); continue; console.log(uTransformed);return;}
+      alert('error at image ' + i + ' ' + uTransformed); continue; console.log(uTransformed); return
+    }
     console.log(i + ': ' + images[i].src + '  file type: ' + fileType)
 
     try {
@@ -41,7 +40,7 @@ function convertImagesToBase64 () {
 
     // chrome.extension.sendRequest({url: img.src})
     // chrome.extension.getBackgroundPage().adjustImage(img.src)
-    } catch(e) {
+    } catch (e) {
       console.log(e)
       return
     }

--- a/js/imagesFromCSSExtractor.js
+++ b/js/imagesFromCSSExtractor.js
@@ -2,7 +2,7 @@
 function getallBgimages () {
   var url, B = [], A = document.getElementsByTagName('*')
   A = B.slice.call(A, 0, A.length)
-  while(A.length){
+  while (A.length) {
     url = document.deepCss(A.shift(), 'background-image')
     if (url) url = /url\(['"]?([^")]+)/.exec(url) || []
     url = url[1]
@@ -28,7 +28,7 @@ Array.prototype.indexOf = Array.prototype.indexOf ||
 function (what, index) {
   index = index || 0
   var L = this.length
-  while(index < L){
+  while (index < L) {
     if (this[index] === what) return index
     ++index
   }

--- a/js/imagesFromCSSExtractor.js
+++ b/js/imagesFromCSSExtractor.js
@@ -1,19 +1,21 @@
 // Credit to kennebec from http://stackoverflow.com/questions/2430503/list-of-all-background-images-in-dom
 function getallBgimages () {
-  var url, B = [], A = document.getElementsByTagName('*')
+  var url
+  var B = []
+  var A = document.getElementsByTagName('*')
   A = B.slice.call(A, 0, A.length)
   while (A.length) {
     url = document.deepCss(A.shift(), 'background-image')
     if (url) url = /url\(['"]?([^")]+)/.exec(url) || []
     url = url[1]
-    if (url && B.indexOf(url) == -1) B[B.length] = url
+    if (url && B.indexOf(url) === -1) B[B.length] = url
   }
   return B
 }
 
 document.deepCss = function (who, css) {
   if (!who || !who.style) return ''
-  var sty = css.replace(/\-([a-z])/g, function (a, b) {
+  var sty = css.replace(/-([a-z])/g, function (a, b) {
     return b.toUpperCase()
   })
   if (who.currentStyle) {
@@ -24,13 +26,13 @@ document.deepCss = function (who, css) {
     dv.getComputedStyle(who, '').getPropertyValue(css) || ''
 }
 
-Array.prototype.indexOf = Array.prototype.indexOf ||
-function (what, index) {
-  index = index || 0
-  var L = this.length
-  while (index < L) {
-    if (this[index] === what) return index
-    ++index
-  }
-  return -1
-}
+// Array.prototype.indexOf = Array.prototype.indexOf ||
+// function (what, index) {
+//   index = index || 0
+//   var L = this.length
+//   while (index < L) {
+//     if (this[index] === what) return index
+//     ++index
+//   }
+//   return -1
+// }

--- a/js/options.js
+++ b/js/options.js
@@ -12,7 +12,7 @@ function save_options () {
   if (document.getElementById('addCollectionMetadataCheckbox').checked) {
     localStorage['collectionId'] = $('#collectionId').val()
     localStorage['collectionName'] = $('#collectionName').val()
-  }else {
+  } else {
     localStorage.removeItem('collectionId')
     localStorage.removeItem('collectionName')
   }
@@ -28,12 +28,12 @@ function save_options () {
 }
 // Restores select box state to saved value from localStorage.
 function restore_options () {
-  /*var warcSRC = localStorage["warcSRC"]
+  /* var warcSRC = localStorage["warcSRC"]
   var waybackWarcSource = document.getElementById("waybackWarcSource")
   if (!warcSRC || warcSRC == "") {
 	waybackWarcSource.value = "C:\\xampp\\tomcat\\webapps\\ROOT\\files1\\"; //TODO, remove this obsolete code!
     return
-  }*/
+  } */
   // console.log(("Restoring options")
   // console.log((localStorage)
 
@@ -41,8 +41,7 @@ function restore_options () {
   if (localStorage['handlingMethod'] == 'save') {
     document.getElementById('output_save').checked = 'checked'
     document.getElementById('output_display').removeAttribute('checked')
-  }
-  else if (localStorage['handlingMethod'] == 'display') {
+  } else if (localStorage['handlingMethod'] == 'display') {
     document.getElementById('output_save').removeAttribute('checked')
     document.getElementById('output_display').checked = 'checked'
   }
@@ -71,7 +70,7 @@ function checkURI (uri) {
     req.open('GET', uri, false)
     req.send(null)
     return req.status
-  } catch(e) {
+  } catch (e) {
     return -1
   }
 }
@@ -89,10 +88,10 @@ function setSaveChangesButtonEnabledBasedOnOptionsChange () {
 
     if (lastSavedStateString == currentSavedState) {
       $('#save').attr('disabled', 'disabled')
-    }else {
+    } else {
       $('#save').removeAttr('disabled')
     }
-  }else { // set the initial state
+  } else { // set the initial state
     lastSavedStateString = $('#filenameScheme').val() +
     $('#uploadTo').val() +
     $('#collectionId').val() +
@@ -141,7 +140,7 @@ function setupButtonFunctionalityAndVisibility () {
     if ($('#postGeneration_upload').prop('checked')) {
       uploadToURI = $('#uploadTo').val()
       filenameScheme = ''
-    }else {
+    } else {
       uploadToURI = ''
       filenameScheme = $('#filenameScheme').val()
     }
@@ -162,7 +161,7 @@ function fetchSocialStandardSpecification () {
     url: $('#sequentialArchivingSource').val()
   })
     .done(function (data) {
-      // console.log(("Done fetching base spec!");	
+      // console.log(("Done fetching base spec!");
       var specs = []
       for (var homepage = 0; homepage < $(data).children().children().children('homepage').length; homepage++) {
         // convert the XML spec to JS objects. This is ridiculously verbose. There has to be a cleaner way.
@@ -186,7 +185,7 @@ function fetchSocialStandardSpecification () {
           .done(function (data2) {
             var specAsObj = jQuery.parseJSON(xml2json(data2, ''))
             var siteSections = specAsObj.socialMediaWebsite.sections.socialMediaWebsiteSection
-            $('#sections').empty(); // Kill the children (of the section list)
+            $('#sections').empty() // Kill the children (of the section list)
             for (var sectionI = 0; sectionI < siteSections.length; sectionI++) {
               // console.log((siteSections[sectionI].name + " " +siteSections[sectionI].url)
               $('#sections').append('<li><span class="name">' + siteSections[sectionI].name + '</span><span class="url">' + siteSections[sectionI].url + '</span>')
@@ -209,7 +208,6 @@ function displayLocalStorageData () {
     break
   }
   // console.log((XX)
-
 }
 
 function showFilenameExample () { // when the file format scheme changes, update the example
@@ -249,7 +247,7 @@ window.onload = function () {
     // hide/disable the "save to downloads" options if the user's current setting is "upload to"
     $('#filenameScheme').attr('disabled', 'disabled')
     $('#exampleFileName').hide()
-  }else if (localStorage['filenameScheme'] && localStorage['filenameScheme'].length > 0) {
+  } else if (localStorage['filenameScheme'] && localStorage['filenameScheme'].length > 0) {
     $('#filenameScheme').val(localStorage['filenameScheme'])
   }
 
@@ -267,5 +265,5 @@ window.onload = function () {
 
   // show data ready to be used for WARC creation
   // populatePendingContentTable()
-  $('#getPendingContent').click(function () {populatePendingContentTable();})
+  $('#getPendingContent').click(function () { populatePendingContentTable() })
 }

--- a/js/options.js
+++ b/js/options.js
@@ -1,10 +1,10 @@
 // Saves options to localStorage.
-function save_options () {
+function saveOptions () {
   // var waybackWarcSource = document.getElementById('waybackWarcSource').value
-  var handling
   // if(document.getElementById('output_save').checked == "checked"){handling = "save";}
   // else if(document.getElementById('output_display').checked == "checked"){handling = "display";}
   // localStorage["warcSRC"] = waybackWarcSource
+  var handling
   localStorage['handlingMethod'] = handling
 
   // console.log((localStorage)
@@ -27,21 +27,21 @@ function save_options () {
   }, 750)
 }
 // Restores select box state to saved value from localStorage.
-function restore_options () {
+function restoreOptions () {
   /* var warcSRC = localStorage["warcSRC"]
-  var waybackWarcSource = document.getElementById("waybackWarcSource")
-  if (!warcSRC || warcSRC == "") {
-	waybackWarcSource.value = "C:\\xampp\\tomcat\\webapps\\ROOT\\files1\\"; //TODO, remove this obsolete code!
-    return
-  } */
+   var waybackWarcSource = document.getElementById("waybackWarcSource")
+   if (!warcSRC || warcSRC == "") {
+   waybackWarcSource.value = "C:\\xampp\\tomcat\\webapps\\ROOT\\files1\\"; //TODO, remove this obsolete code!
+   return
+   } */
   // console.log(("Restoring options")
   // console.log((localStorage)
 
   var handling
-  if (localStorage['handlingMethod'] == 'save') {
+  if (localStorage['handlingMethod'] === 'save') {
     document.getElementById('output_save').checked = 'checked'
     document.getElementById('output_display').removeAttribute('checked')
-  } else if (localStorage['handlingMethod'] == 'display') {
+  } else if (localStorage['handlingMethod'] === 'display') {
     document.getElementById('output_save').removeAttribute('checked')
     document.getElementById('output_display').checked = 'checked'
   }
@@ -58,9 +58,9 @@ function restore_options () {
 // waybackWarcSource.value = warcSRC
 }
 
-function clear_options () {
+function clearOptions () {
   localStorage['warcSRC'] = ''
-  restore_options()
+  restoreOptions()
   document.getElementById('waybackWarcSource').value = 'sdf'
 }
 
@@ -77,28 +77,28 @@ function checkURI (uri) {
 
 var lastSavedStateString = '' // string representation of the last saved state of the form inputs
 function setSaveChangesButtonEnabledBasedOnOptionsChange () {
-  if (lastSavedStateString != '') {
+  if (lastSavedStateString !== '') {
     var currentSavedState = $('#filenameScheme').val() +
-    $('#uploadTo').val() +
-    $('#collectionId').val() +
-    $('#collectionName').val() +
-    $('#postGeneration_save').is(':checked') +
-    $('#postGeneration_upload').is(':checked') +
-    $('#addCollectionMetadataCheckbox').is(':checked')
+      $('#uploadTo').val() +
+      $('#collectionId').val() +
+      $('#collectionName').val() +
+      $('#postGeneration_save').is(':checked') +
+      $('#postGeneration_upload').is(':checked') +
+      $('#addCollectionMetadataCheckbox').is(':checked')
 
-    if (lastSavedStateString == currentSavedState) {
+    if (lastSavedStateString === currentSavedState) {
       $('#save').attr('disabled', 'disabled')
     } else {
       $('#save').removeAttr('disabled')
     }
   } else { // set the initial state
     lastSavedStateString = $('#filenameScheme').val() +
-    $('#uploadTo').val() +
-    $('#collectionId').val() +
-    $('#collectionName').val() +
-    $('#postGeneration_save').is(':checked') +
-    $('#postGeneration_upload').is(':checked') +
-    $('#addCollectionMetadataCheckbox').is(':checked')
+      $('#uploadTo').val() +
+      $('#collectionId').val() +
+      $('#collectionName').val() +
+      $('#postGeneration_save').is(':checked') +
+      $('#postGeneration_upload').is(':checked') +
+      $('#addCollectionMetadataCheckbox').is(':checked')
 
     $('#save').attr('disabled', 'disabled')
     $('#filenameScheme').on('keyup', setSaveChangesButtonEnabledBasedOnOptionsChange)
@@ -152,7 +152,7 @@ function setupButtonFunctionalityAndVisibility () {
     localStorage['collectionName'] = $('#collectionName').val()
 
     // TODO: give feedback that options have been saved
-    save_options()
+    saveOptions()
   })
 }
 
@@ -167,13 +167,13 @@ function fetchSocialStandardSpecification () {
         // convert the XML spec to JS objects. This is ridiculously verbose. There has to be a cleaner way.
         var str = $(data).children().children()[homepage]
         var chiln = $(str).children()
-        var obj = { }
+        var obj = {}
         for (var ii = 0; ii < chiln.length; ii++) {
           obj[chiln[ii].tagName] = chiln[ii].textContent
         }
         specs.push(obj)
 
-        $('#supportedSequentialArchivingSites').append('<option title="' + obj.specification + '">' + obj.homepage + '</option>')
+        $('#supportedSequentialArchivingSites').append(`<option title="${obj.specification}">${obj.homepage}</option>`)
       }
       // attempt to fetch and parse a site-specific hierarchy specification so the section of the website can be extracted and used as the basis of a crawl
       $('#supportedSequentialArchivingSites').change(function () {
@@ -188,7 +188,7 @@ function fetchSocialStandardSpecification () {
             $('#sections').empty() // Kill the children (of the section list)
             for (var sectionI = 0; sectionI < siteSections.length; sectionI++) {
               // console.log((siteSections[sectionI].name + " " +siteSections[sectionI].url)
-              $('#sections').append('<li><span class="name">' + siteSections[sectionI].name + '</span><span class="url">' + siteSections[sectionI].url + '</span>')
+              $('#sections').append(`<li><span class="name">${siteSections[sectionI].name}</span><span class="url">${siteSections[sectionI].url}</span>`)
             }
           })
       })
@@ -219,11 +219,7 @@ function populatePendingContentTable () {
   $('#pendingContentTable .data').remove()
   for (var key = 0; key < Object.keys(responseHeaders).length; key++) {
     var k = Object.keys(responseHeaders)[key]
-    var str = '<tr class="data">' +
-      '<td>' + k + '</td>' +
-      "<td class='#req'>" + requestHeaders[k].length + '</td>' +
-      "<td class='#res'>" + responseHeaders[k].length + '</td>' +
-      '</tr>'
+    var str = `<tr class="data"><td>${k}</td><td class='#req'>${requestHeaders[k].length}</td><td class='#res'>${responseHeaders[k].length}</td></tr>`
     targetTable.append(str)
     str = ''
   }
@@ -258,7 +254,7 @@ window.onload = function () {
   setSaveChangesButtonEnabledBasedOnOptionsChange() // set enabled status of the save button initially
   showFilenameExample() // fire the keyup event onload
 
-  restore_options()
+  restoreOptions()
 
   // fetch socialstandard data
   fetchSocialStandardSpecification()

--- a/js/warc.js
+++ b/js/warc.js
@@ -6,7 +6,8 @@ Warc = function (srcStr) {
 
     function WarcRecord () {
       this.str = ''
-      function WarcInfoHeader () {var str
+      function WarcInfoHeader () {
+        var str
         addLine('WARC/1.0')
       }
       function WarcInfoContent () {}
@@ -22,5 +23,5 @@ Warc = function (srcStr) {
       function addLine (str) {
         this.str += str + '\r\n'
       }
-  }
+    }
 }

--- a/js/warcGenerator.js
+++ b/js/warcGenerator.js
@@ -14,7 +14,7 @@ function str2ab (str) {
   var i = 0
   var strLen = s.length
   for (; i < strLen; i++) {
-    bufView[ i ] = s.charCodeAt(i)
+    bufView[i] = s.charCodeAt(i)
   }
   return buf
 }
@@ -107,7 +107,7 @@ var WARCEntryCreator = {
 
     // DUCTTAPE to fix bug #62
     // - fix the content length to be representative of the un-zipped text content
-    // N0taN3rd: added \r\n instead of \n here to address warc indexing issues with pywb et all see issue #17
+    // added \r\n instead of \n here to address warc indexing issues #17 and #78
     var fixContentLength = `Content-Length: ${lengthInUtf8Bytes(docHtml)}${this.CRLF}`
     newInitURIHeaders = newInitURIHeaders.replace(this.contentLengthRe, fixContentLength)
 
@@ -131,11 +131,11 @@ var helperREs = {
 
 function asynchronouslyFetchImageData (rh, now, warcConcurrentTo, arrayBuffers, responsesToConcatenate, fileName) {
   chrome.storage.local.get(rh, function (result) {
-    var rawImageDataAsBytes = result[ rh ]
+    var rawImageDataAsBytes = result[rh]
 
     if (rawImageDataAsBytes) { // we have the data in chrome.storage.local
       // var imgRawString = ''
-      var byteCount = result[ rh ].length
+      var byteCount = result[rh].length
       // var imagesAsObjectsFromJSON = rawImageDataAsBytes // redundant of above but testing
 
       var hexValueArrayBuffer = new ArrayBuffer(byteCount)
@@ -144,29 +144,29 @@ function asynchronouslyFetchImageData (rh, now, warcConcurrentTo, arrayBuffers, 
       var index = 0
       // var sstr = ''
       for (; index < byteCount; index++) {
-        hexValueInt8Ary.set([ result[ rh ][ index ] ], ixx)
+        hexValueInt8Ary.set([result[rh][index]], ixx)
         ixx++
       }
 
-      var rhsWithCRLF = `${responseHeaders[ rh ]}${WARCEntryCreator.CRLF}`
+      var rhsWithCRLF = `${responseHeaders[rh]}${WARCEntryCreator.CRLF}`
       var hexValueInt8AryPlusRecordSep = hexValueInt8Ary.length + WARCEntryCreator.warcRecordSeparator.length
       var rhsTemp = WARCEntryCreator.makeWarcResponseHeaderWith(rh, now, warcConcurrentTo, rhsWithCRLF, hexValueInt8AryPlusRecordSep)
       var responseHeaderString = `${rhsTemp}${WARCEntryCreator.CRLF}`
 
       arrayBuffers.push(str2ab(responseHeaderString))
-      arrayBuffers.push(str2ab(`${responseHeaders[ rh ]}${WARCEntryCreator.CRLF}`))
+      arrayBuffers.push(str2ab(`${responseHeaders[rh]}${WARCEntryCreator.CRLF}`))
       arrayBuffers.push(hexValueInt8Ary.buffer) // Now, add the image data
       arrayBuffers.push(str2ab(`${WARCEntryCreator.warcRecordSeparator}${WARCEntryCreator.warcRecordSeparator}`))
 
-      delete responsesToConcatenate[ rh ]
+      delete responsesToConcatenate[rh]
     } else {
       // if we don't have the image data in localstorage, remove it anyway
-      console.error('We do not have ' + rh + "'s data in cache.")
-      delete responsesToConcatenate[ rh ]
+      console.error('We do not have ' + rh + '\'s data in cache.')
+      delete responsesToConcatenate[rh]
     }
 
     if (Object.keys(responsesToConcatenate).length === 0) {
-      if (!localStorage[ 'uploadTo' ] || localStorage[ 'uploadTo' ].length === 0) {
+      if (!localStorage['uploadTo'] || localStorage['uploadTo'].length === 0) {
         saveAs(new Blob(arrayBuffers), fileName)
       } else {
         uploadWarc(arrayBuffers)
@@ -180,6 +180,7 @@ function asynchronouslyFetchImageData (rh, now, warcConcurrentTo, arrayBuffers, 
 /* ************** END FEROSS-STANDARD STYLE CONFORMITY HELPERS **************  */
 
 function generateWarc (oRequest, oSender, fCallback) {
+  console.log('warcGenerator GenerateWARC')
   if (oRequest.method !== 'generateWarc') {
     return
   }
@@ -198,14 +199,14 @@ function generateWarc (oRequest, oSender, fCallback) {
 
   var warcHeaderContent = WARCEntryCreator.makeWarcHeaderContent(version, isPartOf, warcInfoDescription)
   var warcHeader = WARCEntryCreator.makeWarcHeader(now, fileName, warcHeaderContent.length)
-  var warcRequest = requestHeaders[ initURI ]
+  var warcRequest = requestHeaders[initURI]
   var warcConcurrentTo = WARCEntryCreator.guidGenerator()
   var warcRequestHeader = WARCEntryCreator.makeWarcRequestHeaderWith(initURI, now, warcConcurrentTo, warcRequest)
 
   var outlinks = oRequest.outlinks.split('|||')
   var outlinkStr = ''
   for (var outlink in outlinks) {
-    var href = outlinks[ outlink ]
+    var href = outlinks[outlink]
     if (href.indexOf('mailto:') > -1) {
       continue
     }
@@ -220,9 +221,9 @@ function generateWarc (oRequest, oSender, fCallback) {
   var warcMetadata = outlinkStr
   var warcMetadataHeader = WARCEntryCreator.makeWarcMetadataHeader(initURI, now, warcMetadata.length)
 
-  responseHeaders[ initURI ] = WARCEntryCreator.touchUpInitURIHeaders(responseHeaders[ initURI ], oRequest.docHtml)
+  responseHeaders[initURI] = WARCEntryCreator.touchUpInitURIHeaders(responseHeaders[initURI], oRequest.docHtml)
 
-  var warcResponse = `${responseHeaders[ initURI ]}${WARCEntryCreator.CRLF}${oRequest.docHtml}${WARCEntryCreator.CRLF}`
+  var warcResponse = `${responseHeaders[initURI]}${WARCEntryCreator.CRLF}${oRequest.docHtml}${WARCEntryCreator.CRLF}`
 
   // alert('Warc response length is '+warcResponse.length +' vs. '+lengthInUtf8Bytes(warcResponse))
   // var htmlLengthCorrection = warcResponse.length - lengthInUtf8Bytes(warcResponse); //html count shouldn't use the method in makeWarcresponseHeader, pass a negative correction value
@@ -241,9 +242,9 @@ function generateWarc (oRequest, oSender, fCallback) {
 
   // old content? not sure. Keep here until we can verify
   var myArray = helperREs.whileMyArrayRe.exec(oRequest.headers)
-  var str = ''
+  var str = '' // eslint-disable-line no-unused-vars
   while (myArray !== null) {
-    str += myArray[ 1 ]
+    str += myArray[1]
     myArray = helperREs.whileMyArrayRe.exec(oRequest.headers)
   }
 
@@ -265,8 +266,8 @@ function generateWarc (oRequest, oSender, fCallback) {
   // var imgData
   var cssURIs
   var cssData
-  // var jsURIs
-  // var jsData
+  var jsURIs
+  var jsData
 
   // if (oRequest.imgURIs) {
   //   imgURIs = oRequest.imgURIs.split('|||')
@@ -280,12 +281,12 @@ function generateWarc (oRequest, oSender, fCallback) {
   if (oRequest.cssData) {
     cssData = oRequest.cssData.split('|||')
   }
-  // if (oRequest.jsURIs) {
-  //   jsURIs = oRequest.jsURIs.split('|||')
-  // }
-  // if (oRequest.jsData) {
-  //   jsData = oRequest.jsData.split('|||')
-  // }
+  if (oRequest.jsURIs) {
+    jsURIs = oRequest.jsURIs.split('|||')
+  }
+  if (oRequest.jsData) {
+    jsData = oRequest.jsData.split('|||')
+  }
 
   // var seedURL = true
   var responsesToConcatenate = []
@@ -294,31 +295,31 @@ function generateWarc (oRequest, oSender, fCallback) {
     if (requestHeader === initURI) {
       continue // the 'seed' will not have a body, we handle this above, skip
     }
-    var rhsTemp = WARCEntryCreator.makeWarcRequestHeaderWith(requestHeader, now, warcConcurrentTo, requestHeaders[ requestHeader ])
+    var rhsTemp = WARCEntryCreator.makeWarcRequestHeaderWith(requestHeader, now, warcConcurrentTo, requestHeaders[requestHeader])
     var requestHeaderString = `${rhsTemp}${WARCEntryCreator.CRLF}`
     arrayBuffers.push(str2ab(requestHeaderString))
 
     if (
-      responseHeaders[ requestHeader ] &&
-      helperREs.imgregexp.exec(responseHeaders[ requestHeader ]) !== null &&
-      responseHeaders[ requestHeader ].indexOf('icon') === -1) {
-      responsesToConcatenate[ requestHeader ] = 'pending'
+      responseHeaders[requestHeader] &&
+      helperREs.imgregexp.exec(responseHeaders[requestHeader]) !== null &&
+      responseHeaders[requestHeader].indexOf('icon') === -1) {
+      responsesToConcatenate[requestHeader] = 'pending'
       asynchronouslyFetchImageData(requestHeader, now, warcConcurrentTo, arrayBuffers, responsesToConcatenate, fileName)
     } else if (
-      responseHeaders[ requestHeader ] &&
-      helperREs.cssregexp.exec(responseHeaders[ requestHeader ]) !== null) {
+      responseHeaders[requestHeader] &&
+      helperREs.cssregexp.exec(responseHeaders[requestHeader]) !== null) {
       if (!cssURIs) {
         break
       }
-      responsesToConcatenate[ requestHeader ] = 'pending'
+      responsesToConcatenate[requestHeader] = 'pending'
       console.log(requestHeader + ' is a CSS file')
-      var respHeader = `${responseHeaders[ requestHeader ]}${WARCEntryCreator.warcRecordSeparator}`
-      var respContent = ''
+      var respHeader = `${responseHeaders[requestHeader]}${WARCEntryCreator.warcRecordSeparator}`
+      var respContent
       var cc = 0
       var cssURIsLen = cssURIs.length
       for (; cc < cssURIsLen; cc++) {
-        if (requestHeader === cssURIs[ cc ]) {
-          respContent += `${cssData[ cssURIs.indexOf(requestHeader) ]}${WARCEntryCreator.warcRecordSeparator}`
+        if (requestHeader === cssURIs[cc]) {
+          respContent = `${cssData[cssURIs.indexOf(requestHeader)]}${WARCEntryCreator.warcRecordSeparator}`
           break
         }
       }
@@ -327,7 +328,25 @@ function generateWarc (oRequest, oSender, fCallback) {
       arrayBuffers.push(str2ab(cssResponseHeaderString))
 
       arrayBuffers.push(str2ab(`${respHeader}${respContent}${WARCEntryCreator.warcRecordSeparator}`))
-      delete responsesToConcatenate[ requestHeader ]
+      delete responsesToConcatenate[requestHeader]
+    } else if (responseHeaders[requestHeader] && helperREs.jsregexp.exec(responseHeaders[requestHeader]) !== null) {
+      // for #82
+      var jsRespHeader = `${responseHeaders[requestHeader]}${WARCEntryCreator.warcRecordSeparator}`
+      var jsRespContent
+      var jsIdx = 0
+      var jsURIsLen = jsURIs.length
+      for (; jsIdx < jsURIsLen; jsIdx++) {
+        if (requestHeader === jsURIs[jsIdx]) {
+          jsRespContent = `${jsData[jsURIs.indexOf(requestHeader)]}${WARCEntryCreator.warcRecordSeparator}`
+          break
+        }
+      }
+      var jsRHSTemp = WARCEntryCreator.makeWarcResponseHeaderWith(requestHeader, now, warcConcurrentTo, jsRespHeader + jsRespContent)
+      var jsResponseHeaderString = `${jsRHSTemp}${WARCEntryCreator.CRLF}`
+      arrayBuffers.push(str2ab(jsResponseHeaderString))
+
+      arrayBuffers.push(str2ab(`${jsRespHeader}${jsRespContent}${WARCEntryCreator.warcRecordSeparator}`))
+      delete responsesToConcatenate[requestHeader]
     }
   }
 
@@ -345,13 +364,13 @@ function generateWarc (oRequest, oSender, fCallback) {
  ************************************************************ */
 
 // from https://developer.mozilla.org/en-US/docs/Web/API/window.btoa
-// function utf8_to_b64 (str) {
-//   return window.btoa(unescape(encodeURIComponent(str)))
-// }
-//
-// function b64_to_utf8 (str) {
-//   return decodeURIComponent(escape(window.atob(str)))
-// }
+function utf8_to_b64 (str) {
+  return window.btoa(unescape(encodeURIComponent(str)))
+}
+
+function b64_to_utf8 (str) {
+  return decodeURIComponent(escape(window.atob(str)))
+}
 
 function getVersion (callback) {
   var xmlhttp = new XMLHttpRequest()
@@ -365,7 +384,7 @@ function getVersion (callback) {
 
 function uploadWarc (abArray) {
   var blobFromArrayBuffers = new Blob(abArray)
-  console.log('Uploading WARC to ' + localStorage[ 'uploadTo' ])
+  console.log('Uploading WARC to ' + localStorage['uploadTo'])
 
   var ajaxRequest = new XMLHttpRequest()
 
@@ -378,7 +397,7 @@ function uploadWarc (abArray) {
   progressObj.progress = 0
   chrome.notifications.create('id1', progressObj, function () {})
   chrome.notifications.onButtonClicked.addListener(function (id, buttonIndex) {
-    chrome.tabs.create({ url: warcfileURI })
+    chrome.tabs.create({url: warcfileURI})
   })
 
   function updateNotification (perc) {
@@ -386,7 +405,7 @@ function uploadWarc (abArray) {
     chrome.notifications.update('id1', progressObj, function () {})
   }
 
-  ajaxRequest.open('POST', localStorage[ 'uploadTo' ], true)
+  ajaxRequest.open('POST', localStorage['uploadTo'], true)
 
   ajaxRequest.onreadystatechange = function () {
     updateNotification(25 * ajaxRequest.readyState)
@@ -394,7 +413,7 @@ function uploadWarc (abArray) {
       progressObj.message = ajaxRequest.responseText
       progressObj.iconUrl = '../icons/icon-check-128.png'
       progressObj.title = 'WARC Uploaded'
-      progressObj.buttons = [ { title: 'View WARC file', iconUrl: '../icons/icon-viewing.png' } ]
+      progressObj.buttons = [{title: 'View WARC file', iconUrl: '../icons/icon-viewing.png'}]
       setTimeout(function () { updateNotification(100) }, 500)
       if (ajaxRequest.status === 201 && ajaxRequest.responseText.length > 0) {
         warcfileURI = ajaxRequest.responseText

--- a/js/warcGenerator.js
+++ b/js/warcGenerator.js
@@ -2,28 +2,30 @@
 
 /* ************** BEGIN STRING UTILITY FUNCTIONS **************  */
 
-function ab2str (buf) {
-  var s = String.fromCharCode.apply(null, new Uint8Array(buf))
-  return decode_utf8(decode_utf8(s))
-}
+// function ab2str (buf) {
+//   var s = String.fromCharCode.apply(null, new Uint8Array(buf))
+//   return decodeUtf8(decodeUtf8(s))
+// }
 
 function str2ab (str) {
-  var s = encode_utf8(str)
+  var s = encodeUtf8(str)
   var buf = new ArrayBuffer(s.length) // 2 bytes for each char
   var bufView = new Uint8Array(buf)
-  for (var i = 0, strLen = s.length; i < strLen; i++) {
-    bufView[i] = s.charCodeAt(i)
+  var i = 0
+  var strLen = s.length
+  for (; i < strLen; i++) {
+    bufView[ i ] = s.charCodeAt(i)
   }
   return buf
 }
 
-function encode_utf8 (s) {
+function encodeUtf8 (s) {
   return unescape(encodeURIComponent(s))
 }
 
-function decode_utf8 (s) {
-  return decodeURIComponent(escape(s))
-}
+// function decodeUtf8 (s) {
+//   return decodeURIComponent(escape(s))
+// }
 
 function lengthInUtf8Bytes (str) {
   // Matches only the 10.. bytes that are non-initial characters in a multi-byte sequence.
@@ -33,298 +35,303 @@ function lengthInUtf8Bytes (str) {
 
 /* ************** END STRING UTILITY FUNCTIONS **************  */
 
-function generateWarc (o_request, o_sender, f_callback) {
-  if (o_request.method !== 'generateWarc') {return }
-  var CRLF = '\r\n'
+/* ************** BEGIN WARC CONTENT CREATOR UTILITY OBJECT **************  */
 
-  // from http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript
-  function guidGenerator () {
-    var S4 = function () {
-      return (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1)
+var WARCEntryCreator = {
+  CRLF: '\r\n',
+  warcRecordSeparator: '\r\n\r\n',
+  contentLengthRe: /Content-Length:.*\r\n/gi,
+  contentEncodingGZRe: /Content-Encoding.*gzip\r\n/gi,
+  makeWarcHeaderContent (version, isPartOf, warcInfoDescription) {
+    // ES6 template preserve the spaces and implicit newline characters added when putting content on the line below
+    var whc = `software: WARCreate/${version} http://warcreate.com${this.CRLF}format: WARC File Format 1.0${this.CRLF}`
+    whc += `conformsTo: http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1_latestdraft.pdf${this.CRLF}`
+    whc += `isPartOf:  ${isPartOf}${this.CRLF}description:  ${warcInfoDescription}${this.CRLF}`
+    whc += `robots: ignore${this.CRLF}http-header-user-agent:  ${navigator.userAgent}${this.CRLF}`
+    whc += `http-header-from: warcreate@matkelly.com ${this.CRLF}${this.CRLF}`
+    return whc
+  },
+  makeWarcHeader (now, fileName, contentLen) {
+    var wh = `WARC/1.0${this.CRLF}WARC-Type: warcinfo${this.CRLF}WARC-Date: ${now}${this.CRLF}`
+    wh += `WARC-Filename: ${fileName}${this.CRLF}WARC-Record-ID: ${this.guidGenerator()}${this.CRLF}`
+    wh += `Content-Type: application/warc-fields${this.CRLF}Content-Length: ${contentLen}${this.CRLF}`
+    return wh
+  },
+  makeWarcMetadataHeader (initURI, now, warcMetadataLen) {
+    var wmh = `WARC/1.0${this.CRLF}WARC-Type: metadata${this.CRLF}WARC-Target-URI: ${initURI}${this.CRLF}WARC-Date: ${now}${this.CRLF}`
+    wmh += `WARC-Concurrent-To: <urn:uuid:dddc4ba2-c1e1-459b-8d0d-a98a20b87e96>${this.CRLF}WARC-Record-ID: <urn:uuid:6fef2a49-a9ba-4b40-9f4a-5ca5db1fd5c6>${this.CRLF}`
+    wmh += `Content-Type: application/warc-fields${this.CRLF}Content-Length: ${warcMetadataLen}${this.CRLF}`
+    return wmh
+  },
+  makeWarcRequestHeaderWith (targetURI, now, warcConcurrentTo, warcRequest) {
+    var wrh = `WARC/1.0${this.CRLF}WARC-Type: request${this.CRLF}WARC-Target-URI: ${targetURI}${this.CRLF}`
+    wrh += `WARC-Date: ${now}${this.CRLF}WARC-Concurrent-To: ${warcConcurrentTo}${this.CRLF}`
+    wrh += `WARC-Record-ID: ${this.guidGenerator()}${this.CRLF}Content-Type: application/http; msgtype=request${this.CRLF}`
+    wrh += `Content-Length: ${warcRequest.length + 2}${this.CRLF}${this.CRLF}${warcRequest}${this.CRLF}${this.CRLF}`
+    return wrh
+  },
+  makeWarcResponseHeaderWith (targetURI, now, warcConcurrentTo, resp, additionalContentLength) {
+    var httpHeader = resp.substring(0, resp.indexOf('\r\n\r\n'))
+    if (httpHeader === '') {
+      httpHeader = resp
     }
-    return '<urn:uuid:' + (S4() + S4() + '-' + S4() + '-' + S4() + '-' + S4() + '-' + S4() + S4() + S4()) + '>'
+    // var countCorrect = httpHeader.match(/\r\n/g).length // Number of lines in xx below
+    var contentLength = lengthInUtf8Bytes(resp)
+    if (additionalContentLength) {
+      contentLength += additionalContentLength
+    }
+    var wrh = `WARC/1.0${this.CRLF}WARC-Type: response${this.CRLF}WARC-Target-URI: ${targetURI}${this.CRLF}`
+    wrh += `WARC-Date: ${now}${this.CRLF}WARC-Record-ID: ${this.guidGenerator()}${this.CRLF}`
+    wrh += `Content-Type: application/http; msgtype=response${this.CRLF}Content-Length: ${contentLength}${this.CRLF}`
+    return wrh
+  },
+  _s4 () {
+    return (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1)
+  },
+  genUUID () {
+    return `${this._s4()}${this._s4()}-${this._s4()}-${this._s4()}-${this._s4()}-${this._s4()}${this._s4()}${this._s4()}`
+  },
+  guidGenerator () {
+    // from http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript
+    return `<urn:uuid:${this.genUUID()}>`
+  },
+  touchUpInitURIHeaders (initURIHeaders, docHtml) {
+    // targetURI
+    // DUCTTAPE
+    var newInitURIHeaders = initURIHeaders
+    if (newInitURIHeaders.indexOf('twitter.com') > -1) {
+      newInitURIHeaders = newInitURIHeaders.replace('text/javascript', 'text/html')
+    }
+    // DUCTTAPE to fix bug #53
+    newInitURIHeaders = newInitURIHeaders.replace('HTTP/1.1 304 Not Modified', 'HTTP/1.1 200 OK')
+
+    // DUCTTAPE to fix bug #62
+    // - fix the content length to be representative of the un-zipped text content
+    // N0taN3rd: added \r\n instead of \n here to address warc indexing issues with pywb et all see issue #17
+    var fixContentLength = `Content-Length: ${lengthInUtf8Bytes(docHtml)}${this.CRLF}`
+    newInitURIHeaders = newInitURIHeaders.replace(this.contentLengthRe, fixContentLength)
+
+    // - remove reference to GZip HTML (or text) body, as we're querying the DOM, not getting the raw feed
+    newInitURIHeaders = newInitURIHeaders.replace(this.contentEncodingGZRe, '')
+    return newInitURIHeaders
   }
+}
 
+/* ************** END WARC CONTENT CREATOR UTILITY OBJECT **************  */
 
+/* ************** BEGING FEROSS-STANDARD STYLE CONFORMITY HELPERS **************  */
+
+var helperREs = {
+  jsregexp: new RegExp('content-type:[ ]*(text|application)/(javascript|js)', 'i'),
+  imgregexp: new RegExp('content-type:[ ]*image/', 'i'),
+  cssregexp: new RegExp('content-type:[ ]*text/(css|stylesheet)', 'i'),
+  fontregexp: new RegExp('content-type:[ ]*font/', 'i'),
+  whileMyArrayRe: /\r\n(.*)\r\n----------------/g
+}
+
+function asynchronouslyFetchImageData (rh, now, warcConcurrentTo, arrayBuffers, responsesToConcatenate, fileName) {
+  chrome.storage.local.get(rh, function (result) {
+    var rawImageDataAsBytes = result[ rh ]
+
+    if (rawImageDataAsBytes) { // we have the data in chrome.storage.local
+      // var imgRawString = ''
+      var byteCount = result[ rh ].length
+      // var imagesAsObjectsFromJSON = rawImageDataAsBytes // redundant of above but testing
+
+      var hexValueArrayBuffer = new ArrayBuffer(byteCount)
+      var hexValueInt8Ary = new Int8Array(hexValueArrayBuffer)
+      var ixx = 0
+      var index = 0
+      // var sstr = ''
+      for (; index < byteCount; index++) {
+        hexValueInt8Ary.set([ result[ rh ][ index ] ], ixx)
+        ixx++
+      }
+
+      var rhsWithCRLF = `${responseHeaders[ rh ]}${WARCEntryCreator.CRLF}`
+      var hexValueInt8AryPlusRecordSep = hexValueInt8Ary.length + WARCEntryCreator.warcRecordSeparator.length
+      var rhsTemp = WARCEntryCreator.makeWarcResponseHeaderWith(rh, now, warcConcurrentTo, rhsWithCRLF, hexValueInt8AryPlusRecordSep)
+      var responseHeaderString = `${rhsTemp}${WARCEntryCreator.CRLF}`
+
+      arrayBuffers.push(str2ab(responseHeaderString))
+      arrayBuffers.push(str2ab(`${responseHeaders[ rh ]}${WARCEntryCreator.CRLF}`))
+      arrayBuffers.push(hexValueInt8Ary.buffer) // Now, add the image data
+      arrayBuffers.push(str2ab(`${WARCEntryCreator.warcRecordSeparator}${WARCEntryCreator.warcRecordSeparator}`))
+
+      delete responsesToConcatenate[ rh ]
+    } else {
+      // if we don't have the image data in localstorage, remove it anyway
+      console.error('We do not have ' + rh + "'s data in cache.")
+      delete responsesToConcatenate[ rh ]
+    }
+
+    if (Object.keys(responsesToConcatenate).length === 0) {
+      if (!localStorage[ 'uploadTo' ] || localStorage[ 'uploadTo' ].length === 0) {
+        saveAs(new Blob(arrayBuffers), fileName)
+      } else {
+        uploadWarc(arrayBuffers)
+      }
+    } else {
+      // console.log(('Still have to process URIs:'+Object.keys(responsesToConcatenate).join(' '))
+    }
+  })
+}
+
+/* ************** END FEROSS-STANDARD STYLE CONFORMITY HELPERS **************  */
+
+function generateWarc (oRequest, oSender, fCallback) {
+  if (oRequest.method !== 'generateWarc') {
+    return
+  }
   var now = new Date().toISOString()
   now = now.substr(0, now.indexOf('.')) + 'Z'
 
-  var nowHttp = new Date().toString('ddd dd MMM yyyy HH:mm:ss') + ' GMT'
-  var fileName = o_request.file
-  var initURI = o_request.url
+  var fileName = oRequest.file
+  var initURI = oRequest.url
 
   var warcInfoDescription = 'Crawl initiated from the WARCreate Google Chrome extension'
   var isPartOf = 'basic'
   if (localStorage.getItem('collectionId') || localStorage.getItem('collectionName')) {
-    warcInfoDescription = 'collectionId=' + localStorage.getItem('collectionId') + ', collectionName="' + localStorage.getItem('collectionName') + '"'
+    warcInfoDescription = `collectionId=${localStorage.getItem('collectionId')}, collectionName="${localStorage.getItem('collectionName')}"`
     isPartOf = localStorage.getItem('collectionId')
   }
 
-  var warcHeaderContent =
-  'software: WARCreate/' + version + ' http://warcreate.com' + CRLF +
-    'format: WARC File Format 1.0' + CRLF +
-    'conformsTo: http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1_latestdraft.pdf' + CRLF +
-    'isPartOf: ' + isPartOf + CRLF +
-    'description: ' + warcInfoDescription + CRLF +
-    'robots: ignore' + CRLF +
-    'http-header-user-agent: ' + navigator.userAgent + CRLF +
-    'http-header-from: warcreate@matkelly.com' + CRLF + CRLF
+  var warcHeaderContent = WARCEntryCreator.makeWarcHeaderContent(version, isPartOf, warcInfoDescription)
+  var warcHeader = WARCEntryCreator.makeWarcHeader(now, fileName, warcHeaderContent.length)
+  var warcRequest = requestHeaders[ initURI ]
+  var warcConcurrentTo = WARCEntryCreator.guidGenerator()
+  var warcRequestHeader = WARCEntryCreator.makeWarcRequestHeaderWith(initURI, now, warcConcurrentTo, warcRequest)
 
-  var warcHeader =
-  'WARC/1.0' + CRLF +
-    'WARC-Type: warcinfo ' + CRLF +
-    'WARC-Date: ' + now + CRLF +
-    'WARC-Filename: ' + fileName + CRLF +
-    'WARC-Record-ID: ' + guidGenerator() + CRLF +
-    'Content-Type: application/warc-fields' + CRLF +
-    'Content-Length: ' + warcHeaderContent.length + CRLF
-
-
-
-  var warcRequest = requestHeaders[initURI]
-
-  var warcConcurrentTo = guidGenerator()
-
-  function makeWarcRequestHeaderWith (targetURI, now, warcConcurrentTo, warcRequest) {
-    var CRLF = '\r\n'
-    var x =
-    'WARC/1.0' + CRLF +
-      'WARC-Type: request' + CRLF +
-      'WARC-Target-URI: ' + targetURI + CRLF +
-      'WARC-Date: ' + now + CRLF +
-      'WARC-Concurrent-To: ' + warcConcurrentTo + CRLF +
-      'WARC-Record-ID: ' + guidGenerator() + CRLF +
-      'Content-Type: application/http; msgtype=request' + CRLF +
-      'Content-Length: ' + (warcRequest.length + 2) + CRLF + CRLF +
-      warcRequest + CRLF + CRLF
-    return x
-  }
-
-
-  var warcRequestHeader = makeWarcRequestHeaderWith(initURI, now, warcConcurrentTo, warcRequest)
-
-
-  var outlinks = o_request.outlinks.split('|||')
+  var outlinks = oRequest.outlinks.split('|||')
   var outlinkStr = ''
   for (var outlink in outlinks) {
-    var href = outlinks[outlink]
-    if (href.indexOf('mailto:') > -1) {continue}
-
-    if (href.substr(0, 1) != 'h') {href = initURI + href} // resolve fragment and internal links
-
-    href = href.substr(0, 8) + href.substr(8).replace(/\/\//g, '/') // replace double slashes outside of scheme
-    outlinkStr += 'outlink: ' + href + CRLF
+    var href = outlinks[ outlink ]
+    if (href.indexOf('mailto:') > -1) {
+      continue
+    }
+    if (href.substr(0, 1) !== 'h') {
+      href = `${initURI}${href}` // resolve fragment and internal links
+    }
+    href = `${href.substr(0, 8)}${href.substr(8).replace(/\/\//g, '/')}` // replace double slashes outside of scheme
+    outlinkStr += `outlink: ${href}${WARCEntryCreator.CRLF}`
   }
 
   // includes initial URI var warcMetadata = "outlink: "+ initURI + CRLF + outlinkStr
   var warcMetadata = outlinkStr
+  var warcMetadataHeader = WARCEntryCreator.makeWarcMetadataHeader(initURI, now, warcMetadata.length)
 
+  responseHeaders[ initURI ] = WARCEntryCreator.touchUpInitURIHeaders(responseHeaders[ initURI ], oRequest.docHtml)
 
-  var warcMetadataHeader =
-  'WARC/1.0' + CRLF +
-    'WARC-Type: metadata' + CRLF +
-    'WARC-Target-URI: ' + initURI + CRLF +
-    'WARC-Date: ' + now + CRLF +
-    'WARC-Concurrent-To: <urn:uuid:dddc4ba2-c1e1-459b-8d0d-a98a20b87e96>' + CRLF +
-    'WARC-Record-ID: <urn:uuid:6fef2a49-a9ba-4b40-9f4a-5ca5db1fd5c6>' + CRLF +
-    'Content-Type: application/warc-fields' + CRLF +
-    'Content-Length: ' + warcMetadata.length + CRLF
+  var warcResponse = `${responseHeaders[ initURI ]}${WARCEntryCreator.CRLF}${oRequest.docHtml}${WARCEntryCreator.CRLF}`
 
-  // targetURI
-  // DUCTTAPE
-  if (initURI.indexOf('twitter.com') > -1) {
-    responseHeaders[initURI] = responseHeaders[initURI].replace('text/javascript', 'text/html')
-  }
-  // DUCTTAPE to fix bug #53
-  responseHeaders[initURI] = responseHeaders[initURI].replace('HTTP/1.1 304 Not Modified', 'HTTP/1.1 200 OK')
-
-
-  // DUCTTAPE to fix bug #62
-  // - fix the content length to be representative of the un-zipped text content
-  responseHeaders[initURI] = responseHeaders[initURI].replace(/Content-Length:.*\r\n/gi, 'Content-Length: ' + lengthInUtf8Bytes(o_request.docHtml) + '\n')
-
-  // - remove reference to GZip HTML (or text) body, as we're querying the DOM, not getting the raw feed
-  responseHeaders[initURI] = responseHeaders[initURI].replace(/Content-Encoding.*gzip\r\n/gi, '')
-
-  warcResponse =
-    responseHeaders[initURI] +
-    CRLF + o_request.docHtml + CRLF
-
-  function makeWarcResponseHeaderWith (targetURI, now, warcConcurrentTo, resp, additionalContentLength) {
-    var httpHeader = resp.substring(0, resp.indexOf('\r\n\r\n'))
-
-    if (httpHeader == '') {
-      httpHeader = resp
-    }
-
-    var countCorrect = httpHeader.match(/\r\n/g).length // Number of lines in xx below
-
-    // var contentLength = (encodeURI(resp).split(/%..|./).length - 1)
-    var contentLength = lengthInUtf8Bytes(resp)
-    if (additionalContentLength) {contentLength += additionalContentLength} // (arraybuffer + string).length don't mix )
-
-    var xx =
-    'WARC/1.0' + CRLF +
-      'WARC-Type: response' + CRLF +
-      'WARC-Target-URI: ' + targetURI + CRLF +
-      'WARC-Date: ' + now + CRLF +
-      'WARC-Record-ID: ' + guidGenerator() + CRLF +
-      'Content-Type: application/http; msgtype=response' + CRLF +
-      // 'Content-Length: ' + (unescape(encodeURIComponent(resp)).length + countCorrect) + CRLF	 //11260 len
-      // 'Content-Length: ' + (resp.length) + CRLF;// + countCorrect) + CRLF;	
-      'Content-Length: ' + contentLength + CRLF
-      // 'Content-Length: ' + lengthInUtf8Bytes(resp) + CRLF
-
-    return xx
-  }
   // alert('Warc response length is '+warcResponse.length +' vs. '+lengthInUtf8Bytes(warcResponse))
   // var htmlLengthCorrection = warcResponse.length - lengthInUtf8Bytes(warcResponse); //html count shouldn't use the method in makeWarcresponseHeader, pass a negative correction value
   // above doesn't work and only messes up content length. No adjustment needed, 0 passed below
 
-  var warcResponseHeader = makeWarcResponseHeaderWith(initURI, now, warcConcurrentTo, warcResponse, 0); // htmlLengthCorrection);	
+  var warcResponseHeader = WARCEntryCreator.makeWarcResponseHeaderWith(initURI, now, warcConcurrentTo, warcResponse, 0)
 
-
-  /*var warc =
-  	warcHeader + CRLF +
-  	warcHeaderContent + CRLF + CRLF +
-  	warcRequestHeader + CRLF + 
-  	warcMetadataHeader + CRLF +
-  	warcMetadata + CRLF + CRLF  +
-  	warcResponseHeader + CRLF +
-  	warcResponse + CRLF + CRLF;*/
-
+  /* var warc =
+   warcHeader + CRLF +
+   warcHeaderContent + CRLF + CRLF +
+   warcRequestHeader + CRLF +
+   warcMetadataHeader + CRLF +
+   warcMetadata + CRLF + CRLF  +
+   warcResponseHeader + CRLF +
+   warcResponse + CRLF + CRLF; */
 
   // old content? not sure. Keep here until we can verify
-  var pattern = /\r\n(.*)\r\n----------------/g
-  var myArray = pattern.exec(o_request.headers)
+  var myArray = helperREs.whileMyArrayRe.exec(oRequest.headers)
   var str = ''
-  while(myArray != null){
-    str += myArray[1]
-    myArray = pattern.exec(o_request.headers)
+  while (myArray !== null) {
+    str += myArray[ 1 ]
+    myArray = helperREs.whileMyArrayRe.exec(oRequest.headers)
   }
-
 
   // localStorage['paiheaders'] = ''
 
+  var arrayBuffers = [] // we will load all of the data in-order in the arrayBuffers array then combine with the file blob to writeout
 
-  var arrayBuffers = []; // we will load all of the data in-order in the arrayBuffers array then combine with the file blob to writeout
-
-  arrayBuffers.push(str2ab(warcHeader + CRLF))
-  arrayBuffers.push(str2ab(warcHeaderContent + CRLF + CRLF))
-  arrayBuffers.push(str2ab(warcRequestHeader + CRLF))
-  arrayBuffers.push(str2ab(warcMetadataHeader + CRLF))
-  arrayBuffers.push(str2ab(warcMetadata + CRLF + CRLF))
-  arrayBuffers.push(str2ab(warcResponseHeader + CRLF))
-  arrayBuffers.push(str2ab(warcResponse + CRLF + CRLF))
+  arrayBuffers.push(str2ab(`${warcHeader}${WARCEntryCreator.CRLF}`))
+  arrayBuffers.push(str2ab(`${warcHeaderContent}${WARCEntryCreator.warcRecordSeparator}`))
+  arrayBuffers.push(str2ab(`${warcRequestHeader}${WARCEntryCreator.CRLF}`))
+  arrayBuffers.push(str2ab(`${warcMetadataHeader}${WARCEntryCreator.CRLF}`))
+  arrayBuffers.push(str2ab(`${warcMetadata}${WARCEntryCreator.warcRecordSeparator}`))
+  arrayBuffers.push(str2ab(`${warcResponseHeader}${WARCEntryCreator.CRLF}`))
+  arrayBuffers.push(str2ab(`${warcResponse}${WARCEntryCreator.warcRecordSeparator}`))
 
   // arrayBuffers.push(str2ab(warc))
 
+  // var imgURIs
+  // var imgData
+  var cssURIs
+  var cssData
+  // var jsURIs
+  // var jsData
 
-  var imgURIs, imgData, cssURIs, cssData, jsURIs, jsData
+  // if (oRequest.imgURIs) {
+  //   imgURIs = oRequest.imgURIs.split('|||')
+  // }
+  // if (oRequest.imgData) {
+  //   imgData = oRequest.imgData.split('|||')
+  // }
+  if (oRequest.cssURIs) {
+    cssURIs = oRequest.cssURIs.split('|||')
+  }
+  if (oRequest.cssData) {
+    cssData = oRequest.cssData.split('|||')
+  }
+  // if (oRequest.jsURIs) {
+  //   jsURIs = oRequest.jsURIs.split('|||')
+  // }
+  // if (oRequest.jsData) {
+  //   jsData = oRequest.jsData.split('|||')
+  // }
 
-  if (o_request.imgURIs) imgURIs = o_request.imgURIs.split('|||')
-  if (o_request.imgData) imgData = o_request.imgData.split('|||')
-  if (o_request.cssURIs) cssURIs = o_request.cssURIs.split('|||')
-  if (o_request.cssData) cssData = o_request.cssData.split('|||')
-  if (o_request.jsURIs) jsURIs = o_request.jsURIs.split('|||')
-  if (o_request.jsData) jsData = o_request.jsData.split('|||')
-
-  var seedURL = true
+  // var seedURL = true
   var responsesToConcatenate = []
 
-  var jsregexp = new RegExp('content-type:[ ]*(text|application)/(javascript|js)', 'i')
-  var imgregexp = new RegExp('content-type:[ ]*image/', 'i')
-  var cssregexp = new RegExp('content-type:[ ]*text/(css|stylesheet)', 'i')
-  var fontregexp = new RegExp('content-type:[ ]*font/', 'i')
-
   for (var requestHeader in requestHeaders) {
-    if (requestHeader == initURI) {continue;} // the 'seed' will not have a body, we handle this above, skip
-
-    var requestHeaderString = makeWarcRequestHeaderWith(requestHeader, now, warcConcurrentTo, requestHeaders[requestHeader]) + CRLF
+    if (requestHeader === initURI) {
+      continue // the 'seed' will not have a body, we handle this above, skip
+    }
+    var rhsTemp = WARCEntryCreator.makeWarcRequestHeaderWith(requestHeader, now, warcConcurrentTo, requestHeaders[ requestHeader ])
+    var requestHeaderString = `${rhsTemp}${WARCEntryCreator.CRLF}`
     arrayBuffers.push(str2ab(requestHeaderString))
 
-
     if (
-      responseHeaders[requestHeader] &&
-      imgregexp.exec(responseHeaders[requestHeader]) != null &&
-      responseHeaders[requestHeader].indexOf('icon') == -1) {
-      responsesToConcatenate[requestHeader] = 'pending'
-      asynchronouslyFetchImageData(requestHeader)
-
-      function asynchronouslyFetchImageData (rh) {
-        chrome.storage.local.get(rh, function (result) {
-          var rawImageDataAsBytes = result[rh]
-
-          if (rawImageDataAsBytes) { // we have the data in chrome.storage.local
-
-            var imgRawString = ''
-
-            var byteCount = result[rh].length
-            var imagesAsObjectsFromJSON = rawImageDataAsBytes // redundant of above but testing
-
-            var hexValueArrayBuffer = new ArrayBuffer(byteCount)
-            var hexValueInt8Ary = new Int8Array(hexValueArrayBuffer)
-            var ixx = 0
-            var sstr = ''
-            for (var index = 0; index < byteCount; index++) {
-              hexValueInt8Ary.set([result[rh][index]], ixx)
-              ixx++
-            }
-
-
-            var responseHeaderString = makeWarcResponseHeaderWith(rh, now, warcConcurrentTo, responseHeaders[rh] + CRLF, hexValueInt8Ary.length + (CRLF + CRLF).length) + CRLF
-
-
-            arrayBuffers.push(str2ab(responseHeaderString))
-            arrayBuffers.push(str2ab(responseHeaders[rh] + CRLF))
-            arrayBuffers.push(hexValueInt8Ary.buffer); // Now, add the image data
-            arrayBuffers.push(str2ab(CRLF + CRLF + CRLF + CRLF))
-
-            delete responsesToConcatenate[rh]
-          } else {
-            // if we don't have the image data in localstorage, remove it anyway
-            console.error('We do not have ' + rh + "'s data in cache.")
-            delete responsesToConcatenate[rh]
-          }
-
-          if (Object.keys(responsesToConcatenate).length == 0) {
-            if (!localStorage['uploadTo'] || localStorage['uploadTo'].length == 0) {
-              saveAs(new Blob(arrayBuffers), fileName)
-            } else {
-              uploadWarc(arrayBuffers)
-            }
-          } else {
-            // console.log(('Still have to process URIs:'+Object.keys(responsesToConcatenate).join(' '))
-          }
-        })
-      }
+      responseHeaders[ requestHeader ] &&
+      helperREs.imgregexp.exec(responseHeaders[ requestHeader ]) !== null &&
+      responseHeaders[ requestHeader ].indexOf('icon') === -1) {
+      responsesToConcatenate[ requestHeader ] = 'pending'
+      asynchronouslyFetchImageData(requestHeader, now, warcConcurrentTo, arrayBuffers, responsesToConcatenate, fileName)
     } else if (
-      responseHeaders[requestHeader] &&
-      cssregexp.exec(responseHeaders[requestHeader]) != null) {
+      responseHeaders[ requestHeader ] &&
+      helperREs.cssregexp.exec(responseHeaders[ requestHeader ]) !== null) {
       if (!cssURIs) {
         break
       }
-      responsesToConcatenate[requestHeader] = 'pending'
+      responsesToConcatenate[ requestHeader ] = 'pending'
       console.log(requestHeader + ' is a CSS file')
-      var respHeader = responseHeaders[requestHeader] + CRLF + CRLF
+      var respHeader = `${responseHeaders[ requestHeader ]}${WARCEntryCreator.warcRecordSeparator}`
       var respContent = ''
-
-      for (var cc = 0; cc < cssURIs.length; cc++) {
-        if (requestHeader == cssURIs[cc]) {
-          respContent += cssData[cssURIs.indexOf(requestHeader)] + CRLF + CRLF
+      var cc = 0
+      var cssURIsLen = cssURIs.length
+      for (; cc < cssURIsLen; cc++) {
+        if (requestHeader === cssURIs[ cc ]) {
+          respContent += `${cssData[ cssURIs.indexOf(requestHeader) ]}${WARCEntryCreator.warcRecordSeparator}`
           break
         }
       }
-
-      var cssResponseHeaderString = makeWarcResponseHeaderWith(requestHeader, now, warcConcurrentTo, respHeader + respContent) + CRLF
+      var cssRHSTemp = WARCEntryCreator.makeWarcResponseHeaderWith(requestHeader, now, warcConcurrentTo, respHeader + respContent)
+      var cssResponseHeaderString = `${cssRHSTemp}${WARCEntryCreator.CRLF}`
       arrayBuffers.push(str2ab(cssResponseHeaderString))
 
-      arrayBuffers.push(str2ab(respHeader + respContent + CRLF + CRLF))
-      delete responsesToConcatenate[requestHeader]
+      arrayBuffers.push(str2ab(`${respHeader}${respContent}${WARCEntryCreator.warcRecordSeparator}`))
+      delete responsesToConcatenate[ requestHeader ]
     }
   }
 
-  if (Object.keys(responsesToConcatenate).length == 0) {
+  if (Object.keys(responsesToConcatenate).length === 0) {
     saveAs(new Blob(arrayBuffers), fileName)
   } else {
     console.log('Still have to process URIs:' + Object.keys(responsesToConcatenate).join(' '))
@@ -332,19 +339,19 @@ function generateWarc (o_request, o_sender, f_callback) {
 }
 
 /* ************************************************************
- 
+
  UTILITY FUNCTIONS
- 
-************************************************************ */
+
+ ************************************************************ */
 
 // from https://developer.mozilla.org/en-US/docs/Web/API/window.btoa
-function utf8_to_b64 (str) {
-  return window.btoa(unescape(encodeURIComponent(str)))
-}
-
-function b64_to_utf8 (str) {
-  return decodeURIComponent(escape(window.atob(str)))
-}
+// function utf8_to_b64 (str) {
+//   return window.btoa(unescape(encodeURIComponent(str)))
+// }
+//
+// function b64_to_utf8 (str) {
+//   return decodeURIComponent(escape(window.atob(str)))
+// }
 
 function getVersion (callback) {
   var xmlhttp = new XMLHttpRequest()
@@ -358,7 +365,7 @@ function getVersion (callback) {
 
 function uploadWarc (abArray) {
   var blobFromArrayBuffers = new Blob(abArray)
-  console.log('Uploading WARC to ' + localStorage['uploadTo'])
+  console.log('Uploading WARC to ' + localStorage[ 'uploadTo' ])
 
   var ajaxRequest = new XMLHttpRequest()
 
@@ -371,7 +378,7 @@ function uploadWarc (abArray) {
   progressObj.progress = 0
   chrome.notifications.create('id1', progressObj, function () {})
   chrome.notifications.onButtonClicked.addListener(function (id, buttonIndex) {
-    chrome.tabs.create({url: warcfileURI})
+    chrome.tabs.create({ url: warcfileURI })
   })
 
   function updateNotification (perc) {
@@ -379,17 +386,17 @@ function uploadWarc (abArray) {
     chrome.notifications.update('id1', progressObj, function () {})
   }
 
-  ajaxRequest.open('POST', localStorage['uploadTo'], true)
+  ajaxRequest.open('POST', localStorage[ 'uploadTo' ], true)
 
   ajaxRequest.onreadystatechange = function () {
     updateNotification(25 * ajaxRequest.readyState)
-    if (ajaxRequest.readyState == 4) {
+    if (ajaxRequest.readyState === 4) {
       progressObj.message = ajaxRequest.responseText
       progressObj.iconUrl = '../icons/icon-check-128.png'
       progressObj.title = 'WARC Uploaded'
-      progressObj.buttons = [{title: 'View WARC file',iconUrl: '../icons/icon-viewing.png'}]
-      setTimeout(function () {updateNotification(100)}, 500)
-      if (ajaxRequest.status == 201 && ajaxRequest.responseText.length > 0) {
+      progressObj.buttons = [ { title: 'View WARC file', iconUrl: '../icons/icon-viewing.png' } ]
+      setTimeout(function () { updateNotification(100) }, 500)
+      if (ajaxRequest.status === 201 && ajaxRequest.responseText.length > 0) {
         warcfileURI = ajaxRequest.responseText
       } else {
         alert('The server accepted the WARC.')
@@ -398,15 +405,15 @@ function uploadWarc (abArray) {
   }
   ajaxRequest.send(blobFromArrayBuffers)
 }
-var warcfileURI = ''; // The Chrome notifications API isn't mature enough to surface data, even via buttons
+var warcfileURI = '' // The Chrome notifications API isn't mature enough to surface data, even via buttons
 
 var version
-getVersion(function (ver) { version = ver; })
+getVersion(function (ver) { version = ver })
 
 /* ************************************************************
- 
+
  INITIAL RUNTIME EXECUTION
- 
-************************************************************ */
+
+ ************************************************************ */
 
 chrome.extension.onRequest.addListener(generateWarc)

--- a/package.json
+++ b/package.json
@@ -20,10 +20,19 @@
     "url": "git://github.com/machawk1/warcreate.git"
   },
   "scripts": {
-    "test": "standard"
+    "test": "standard",
+    "lint": "standard --verbose | snazzy",
+    "linting-errors-fix": "standard --fix"
   },
   "devDependencies": {
-    "standard" :"^3.0.0"
+    "snazzy": "^7.0.0",
+    "standard": "^10.0.2"
+  },
+  "eslintConfig": {
+    "env": {
+      "browser": true,
+      "node": true
+    }
   },
   "standard": {
     "ignore": [
@@ -38,6 +47,22 @@
       "js/jquery.rc4.js",
       "js/upclick-min.js",
       "js/xml2json.js"
+    ],
+    "globals": [
+      "chrome",
+      "localStorage",
+      "alert",
+      "Image",
+      "Blob",
+      "XMLHttpRequest",
+      "navigator",
+      "params",
+      "requestHeaders",
+      "responseHeaders",
+      "saveAs",
+      "$",
+      "jQuery",
+      "xml2json"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ignore": [
       "js/base64.js",
       "js/dnd-lib.js",
+      "js/date.js",
       "js/downloadify/*",
       "js/es6-shim.js",
       "js/filler.min.js",
@@ -62,7 +63,10 @@
       "saveAs",
       "$",
       "jQuery",
-      "xml2json"
+      "xml2json",
+      "moment",
+      "getallBgimages",
+      "getallBgimages"
     ]
   }
 }


### PR DESCRIPTION
# Awesome Project!
Apologies for supper large diffs for this PR and if you want I can break it up. Just let me know.
Wanted to contribute back to WARCreate after using it as a basis for WAIL-WARCreate as without WARCreate my node.js version would not exist.
 
## Addressing #84
bumped standard version 3.0.0 -> 10.0.2 
added devDependency snazzy (https://github.com/feross/snazzy) to help in reporting linting errors
- snazzy helps big time in clearly finding and fixing linting errors.  Used by WAIL

added to package.json scripts:  
- lint: runs standard --verbose piping output to snazzy for reporting
- linting-errors-fix: to automatically fix common standard style errors

added standard configuration to package.json to keep it from
wrongly reporting globals such as `chrome` as no-undef addresses 

ran linting-errors-fix addresses 
- The errors automatically fixed by using this are incorrect spacing,  " -> ' , used a semi and  other simple ones like such
- The errors not automatically fixed by using this are no-undef or camelcase for example 

### Output from standard before this PR 
![warcreatelintbeforeme](https://cloud.githubusercontent.com/assets/8648317/26045760/b01e2f6c-3919-11e7-8bad-bef0e26918e9.png)

### Output from standard at commit 56b4ade of this PR :godmode:
![warcreatelintafterme](https://cloud.githubusercontent.com/assets/8648317/26045860/2f3bbe90-391a-11e7-9331-06257d7ae25b.png)

## fixes for #88 #84 #78 #17 
refactored warcGenerator.js:
- to use ES6 Template String addresses #88
- standardize repo code addresses #84
- contribute back from WAIL-WARCreate to potential fix for #17 and #78 by 
  replacing '\n' with '\r\n' in WARCEntryCreator.touchUpInitURIHeaders in warcGenerator.js
  and de-nodify WAIL-WARCreates warc writing scheme as WAIL-WARCreate would not exist 
  if WARCreate had not done it first

## fix for #82 and rework for #90 
refactored content.js per #90 and to ensure all of the page's resources are in the warc file
which facilitated the fix for #82 by re-adding the writing the of jsData from content.js in warcGenerator.js

I added the ``async`` attribute to 
```js
/*
   per #90 added the async modifier to the function
   NOTE: any error thrown in this function not caught explicitly
   will cause on unhandled rejection error. This may or may not
   be a node.js only thing (will cause node to halt in a future release)
   but the handling of should take place for good standards and practises
   */
  port.onMessage.addListener(async function (msg) {
   .....
```
and "promisfied" ``fetchImage``, ``fetchScriptData``, ``fetchCssData``. Promises used are 100% built in :)
```js
/**
 * Exact functionality of the fetchImage method except returns a promise that calls the resolve
 * function after the image data has been set in local storage.
 * calls the reject function if chrome.lasterror is defined or the XHR requests onerror method is called
 * per #90
 */
function fetchImagePromise (u, ret, imgObjs) {
  return new Promise(function (resolve, reject) {
    var xhr = new XMLHttpRequest()
    xhr.open('GET', u, true)
    xhr.responseType = 'arraybuffer'
    xhr.onload = function (e) {
      var uInt8Array = new Uint8Array(this.response)

      var stringUInt8Array = []
      for (var ii = 0; ii < uInt8Array.length; ii++) {
        stringUInt8Array[ii] = uInt8Array[ii] + 0
      }

      ret[u] = uInt8Array
      delete imgObjs[u]

      // console.log("Ok, now postback image data");
      // console.error(u);
      var ohemefgee = {}
      ohemefgee[u] = stringUInt8Array
      chrome.storage.local.set(ohemefgee, function () {
        if (chrome.runtime.lastError) {
          console.error('Error in set data')
          console.error(chrome.runtime.lastError)
          reject(chrome.runtime.lastError)
        } else {
          resolve()
        }
      })
      // console.log(("- Image data in local storage for "+u)
      // port.postMessage({imageData: JSON.stringify(ret),method: "getImageDataRet",uri: u},function(e){})
    }

    xhr.onerror = function (e) {
      console.log('Error fetchImagePromise content.js', e)
      reject(e)
    }

    xhr.send()
  })
}
```
Then  when calling the function
```js
        try {
          await fetchCssDataPromise(document.styleSheets[ss].href, styleSheetData)
        } catch (error) {
          console.error('there was an error fetching css data content.js', error)
        }
```
finally when generating the WARC
```js
    arrayBuffers.push(str2ab(`${respHeader}${respContent}${WARCEntryCreator.warcRecordSeparator}`))
      delete responsesToConcatenate[requestHeader]
    } else if (responseHeaders[requestHeader] && helperREs.jsregexp.exec(responseHeaders[requestHeader]) !== null) {
      // for #82
      var jsRespHeader = `${responseHeaders[requestHeader]}${WARCEntryCreator.warcRecordSeparator}`
      var jsRespContent
      var jsIdx = 0
      var jsURIsLen = jsURIs.length
      for (; jsIdx < jsURIsLen; jsIdx++) {
        if (requestHeader === jsURIs[jsIdx]) {
          jsRespContent = `${jsData[jsURIs.indexOf(requestHeader)]}${WARCEntryCreator.warcRecordSeparator}`
          break
        }
      }
      var jsRHSTemp = WARCEntryCreator.makeWarcResponseHeaderWith(requestHeader, now, warcConcurrentTo, jsRespHeader + jsRespContent)
      var jsResponseHeaderString = `${jsRHSTemp}${WARCEntryCreator.CRLF}`
      arrayBuffers.push(str2ab(jsResponseHeaderString))

      arrayBuffers.push(str2ab(`${jsRespHeader}${jsRespContent}${WARCEntryCreator.warcRecordSeparator}`))
      delete responsesToConcatenate[requestHeader]
    }
```

## fix for #79 
by adding a listener to onSendHeaders. Avoid duplicates by keeping track per URL which headers have been added so far
```js
/**
 * address #79 by keeping track per URL what headers we have already concatenated
 */
var requestHeadersTracking = []

/**
 * Stores HTTP request headers into an object array with URI as key.
 * issue #79, these headers are not available here:
 * Authorization,Cache-Control,Connection,Content-Length,Host,If-Modified-Since,If-None-Match,If-Range
 * Partial-Data,Pragma,Proxy-Authorization,Proxy-Connection,Transfer-Encoding
 * see https://developer.chrome.com/extensions/webRequest
 */
chrome.webRequest.onBeforeSendHeaders.addListener(function (req) {
  var path = req.url.substring(req.url.match(/[a-zA-Z0-9]\//).index + 1)

  // per #79 keep track of already concatenated headers for warc string
  if (requestHeadersTracking[req.url] === null || requestHeadersTracking[req.url] === undefined) {
    requestHeadersTracking[req.url] = new Set()
  } else {
    requestHeadersTracking[req.url].clear()
  }
  requestHeaders[req.url] = `${req.method} ${path} HTTP/1.1${CRLF}`
  // requestHeaders[req.url] += req.method + ' ' + path + ' ' + FABRICATED_httpVersion + CRLF
  // console.log(("- Request headers received for "+req.url)
  for (var key in req.requestHeaders) {
    requestHeaders[req.url] += `${req.requestHeaders[key].name}: ${req.requestHeaders[key].value}${CRLF}`
    requestHeadersTracking[req.url].add(req.requestHeaders[key].name)
  }
}, {urls: ['http://*/*', 'https://*/*'], tabId: currentTabId}, ['requestHeaders', 'blocking'])

/**
 * Stores HTTP request headers into an object array with URI as key.
 * fix for issue #79, see explanation in onBeforeSendHeaders and documentation for requestHeadersTracking
 */
chrome.webRequest.onSendHeaders.addListener(function (req) {
  for (var key in req.requestHeaders) {
    if (!requestHeadersTracking[req.url].has(req.requestHeaders[key].name)) {
      requestHeaders[req.url] += `${req.requestHeaders[key].name}: ${req.requestHeaders[key].value}${CRLF}`
      requestHeadersTracking[req.url].add(req.requestHeaders[key].name)
    }
  }
}, {urls: ['http://*/*', 'https://*/*'], tabId: currentTabId}, ['requestHeaders'])
```
## fixed #80 
the metadata information for CSS is no longer E =EMBED_MIC it is now E link/@href
```js
     // outlinks as CSS
      $(document.styleSheets).each(function () {
        if (!outlinksAddedRegistry[$(this).attr('href')]) {
          outlinksAddedRegistry[$(this).attr('href')] = ''
          // fixes #80
          outlinks.push(`${$(this).attr('href')} E link/@href`)
        }
      })
```

## fixed #81 
the reason why the script tag links were missing from the warcmetadata
was because the code checking for its existence was looking for the HREF attribute,
 not an src attribute. Not rhetorical this error was simply due to a copy pasta error.
Was the exact code for outlines as CSS and have I ever made my share of these :feelsgood:
```js
 // outlinks as JavaScripts
      $(document.scripts).each(function () {
        if ($(this).attr('src') && // Only include the externally embedded JS, not the inline
          !outlinksAddedRegistry[$(this).attr('src')]
        ) {
          outlinksAddedRegistry[$(this).attr('src')] = ''
          outlinks.push(`${$(this).attr('src')} E script/@src`)
        }
      })
```

## commented out <script src="../js/es6-shim.js"></script>  in html/background.html
Per authors own comments 
```html
<!-- To convert the really high character numbers that are exhibited in image data. 
Keep this until Chrome supports https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint in EC6 --> 
<script src="../js/es6-shim.js"></script> 
``` 
``String.fromCodePoint`` is a built in string function now 

