### PR TITLE
Allow command run from issue comments

### DIFF
--- a/.github/workflows/comment-run.yml
+++ b/.github/workflows/comment-run.yml
@@ -23,4 +23,4 @@ jobs:
       uses: ibnesayeed/actions-comment-run@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        allowed-associations: '["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'
+        allowed-associations: '["OWNER", "COLLABORATOR"]'

--- a/.github/workflows/omment-run.yml
+++ b/.github/workflows/omment-run.yml
@@ -1,0 +1,26 @@
+name: "Comment Run"
+
+on:
+  issue_comment:
+    types:
+      - created
+      - edited
+
+jobs:
+  comment-run:
+    if: contains(github.event.comment.body, '@github-actions run')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code (Deep)
+      uses: actions/checkout@master
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@master
+    - name: Install warcio
+      run: pip install warcio
+    - name: Execute Code in Comment
+      uses: ibnesayeed/actions-comment-run@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        allowed-associations: '["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/*
 !.codeclimate.yml
 !.jshintrc
 !.travis.yml
+!.github


### PR DESCRIPTION
Add a GH Workflow to enable running arbitrary commands from issue comments. This can only be tested once merged first.