### PR TITLE
Catch partial URIs without any relativity indicator

### DIFF
--- a/js/warcGenerator.js
+++ b/js/warcGenerator.js
@@ -214,7 +214,12 @@ function generateWarc (oRequest, oSender, fCallback) {
     href = `${href.substr(0, 8)}${href.substr(8).replace(/\/\//g, '/')}` // replace double slashes outside of scheme
     // Sanitize ../'s
     let parts = href.split(' ')
-    parts[0] = (new window.URL(parts[0])).href
+    try {
+      parts[0] = (new window.URL(parts[0])).href
+    } catch(TypeError) {
+      // Path-only URI encountered, mitigate, see #128
+      parts[0] = `${window.location.origin}/${parts[0]}`
+    }
     href = parts.join(' ')
 
     outlinkStr += `outlink: ${href}${WARCEntryCreator.CRLF}`

--- a/js/warcGenerator.js
+++ b/js/warcGenerator.js
@@ -216,7 +216,7 @@ function generateWarc (oRequest, oSender, fCallback) {
     let parts = href.split(' ')
     try {
       parts[0] = (new window.URL(parts[0])).href
-    } catch(TypeError) {
+    } catch (TypeError) {
       // Path-only URI encountered, mitigate, see #128
       parts[0] = `${window.location.origin}/${parts[0]}`
     }
@@ -335,7 +335,7 @@ function getVersion (callback) {
   let xmlhttp = new XMLHttpRequest()
   xmlhttp.open('GET', '../manifest.json')
   xmlhttp.onload = function (e) {
-    var manifest = JSON.parse(xmlhttp.responseText)
+    const manifest = JSON.parse(xmlhttp.responseText)
     callback(manifest.version)
   }
   xmlhttp.send(null)

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 2,
   "name": "WARCreate",
-  "version": "0.2019.1.19",
-  "version_name": "0.2019.1.19 build 612",
+  "version": "0.2021.6.28",
+  "version_name": "0.2019.6.28 build 1307",
   
   "description": "Create Wayback-Consumable WARC Files from Any Webpage",
   "icons" : {


### PR DESCRIPTION
Hacker News, for instance, references a JS file with just the file
name without any relative indicator (./ or ../), any scheme, or
really anything that would allow it to be parsed as a full URI
with native functionality. This adds a check for this TypeError
and attributes the current hostname/scheme to the partial.

Closes #128